### PR TITLE
Fix type error ( shift count type int, must be unsigned integer )

### DIFF
--- a/font/util.go
+++ b/font/util.go
@@ -125,7 +125,7 @@ func (r *bitmapReader) Read() bool {
 		r.eof = true
 		return false
 	}
-	bit := r.buf[r.pos]&(1<<r.bit) == 1
+	bit := r.buf[r.pos]&(1<<uint(r.bit)) == 1
 	r.bit++
 	if r.bit == 8 {
 		r.bit = 0

--- a/font/woff2.go
+++ b/font/woff2.go
@@ -367,7 +367,7 @@ func parseGlyfTransformed(b []byte) ([]byte, []byte, error) {
 			}
 
 			signInt16 := func(flag byte, pos int) int16 {
-				if flag&(1<<pos) != 0 {
+				if flag&(1<<uint(pos)) != 0 {
 					return 1 // positive if bit on position is set
 				}
 				return -1

--- a/font/woff2.go
+++ b/font/woff2.go
@@ -366,8 +366,8 @@ func parseGlyfTransformed(b []byte) ([]byte, []byte, error) {
 				return nil, nil, ErrInvalidFontData
 			}
 
-			signInt16 := func(flag byte, pos int) int16 {
-				if flag&(1<<uint(pos)) != 0 {
+			signInt16 := func(flag byte, pos uint) int16 {
+				if flag&(1<<pos) != 0 {
 					return 1 // positive if bit on position is set
 				}
 				return -1


### PR DESCRIPTION
The following error occurred when retrieving this library .

```
# github.com/tdewolff/canvas/font
font/util.go:128:22: invalid operation: 1 << r.bit (shift count type int, must be unsigned integer)
font/woff2.go:370:13: invalid operation: 1 << pos (shift count type int, must be unsigned integer)
```