### PR TITLE
pdfPageWriter.SetFont should not ignore size change

### DIFF
--- a/pdf.go
+++ b/pdf.go
@@ -778,7 +778,7 @@ func (w *pdfPageWriter) SetFont(font *Font, size float64) {
 	if !w.inTextObject {
 		panic("must be in text object")
 	}
-	if font != w.font {
+	if font != w.font || w.fontSize != size {
 		w.font = font
 		w.fontSize = size
 


### PR DESCRIPTION
I tried to generate `example/document` to PDF and the output was all messed but, because the font of the paragraph was far to big.

This MR fixes this.

---

The story behind this MR:

I dug into the code (which is quite readable: after playing less than 24h with it, I can find localize quite quickly what I need - kudos for that :tada: ) and manually adjusted the font size by a factor of 0.425.
Adjusting this factor made the paragraph look good, but the title was now too small.
This factor was interestingly close to 12/28=0.428 (12 being the font size of the paragraph, 28 the font size of the title).
So it seemed like the pdf `RenderText` function was not adjusting the font size as it should.
I dug further and found the culprit: `pdfPageWriter.SetFont` was doing nothing if the Font was the same as the previous one, but without looking at the fontSize!

Adding the following 22 chars `|| w.fontSize != size ` (at the right place ;-) fixed the issue.
