### PR TITLE
reduce split overflow

### DIFF
--- a/text.go
+++ b/text.go
@@ -339,9 +339,14 @@ func (rt *RichText) ToText(width, height float64, halign, valign TextAlign, inde
 			} else {
 				spans, ok = spans[0].Split(width - dx)
 			}
-			if !ok && len(ss) != 0 {
-				// span couln't fit, but we have no choice as it's the only span on the line
-				break
+
+			if !ok {
+				if len(ss) != 0 {
+					// span couln't fit, but we have no choice as it's the only span on the line
+					break
+				}
+				// the current span is too large, take the smallest part
+				spans = spans[0].splitFirst()
 			}
 
 			newline := 1 < len(spans[0].boundaries) && spans[0].boundaries[len(spans[0].boundaries)-2].kind == lineBoundary
@@ -646,6 +651,16 @@ func (span textSpan) split(i int) (textSpan, textSpan) {
 		span1.altBoundaries[j].pos -= span.altBoundaries[i].pos + span.altBoundaries[i].size
 	}
 	return span0, span1
+}
+
+func (span textSpan) splitFirst() []textSpan {
+	for i := 0; i <= len(span.boundaries)-2; i++ {
+		if span.boundaries[i].pos > 0 {
+			s1, s2 := span.split(i)
+			return []textSpan{s1, s2}
+		}
+	}
+	return []textSpan{span}
 }
 
 func (span textSpan) Split(width float64) ([]textSpan, bool) {

--- a/text_test.go
+++ b/text_test.go
@@ -142,6 +142,11 @@ func TestRichText(t *testing.T) {
 	rt.Add(face, "\u200bmm")
 	text = rt.ToText(20.0, 50.0, Left, Top, 0.0, 0.0) // wrap at space
 	test.T(t, len(text.lines), 1)
+
+	rt = NewRichText()
+	rt.Add(face, "mmmm mmmm")                         // the first word is longer than the line
+	text = rt.ToText(40.0, 50.0, Left, Top, 0.0, 0.0) // wrap at space
+	test.T(t, len(text.lines), 2)
 }
 
 func TestTextBounds(t *testing.T) {


### PR DESCRIPTION
If a word is too large for a line, force a split just after it.

I removed many spaces from the first line of `example/document` to have a word larger than the paragraph size.
It is expected, that the word is larger, but it is unexpected that the rest of the sentence is not sent to a new line.

Before this MR:
![before](https://user-images.githubusercontent.com/3864879/76852871-8bc57c00-684c-11ea-822d-5aa809a35294.png)

After this MR:
![after](https://user-images.githubusercontent.com/3864879/76852881-908a3000-684c-11ea-85d1-14bb9b57b1e6.png)
