### PR TITLE
Move renderers to subpackages (rasterizer, eps)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: go
 go:
   - 1.13.x
+  - master
 env:
-  - GO111MODULE=on
+  - GO111MODULE=on CGO_ENABLED=0
 before_install:
   - go get github.com/mattn/goveralls
   - sudo apt-get update
   - sudo apt-get install -qq libgl1-mesa-dev xorg-dev
   - rm -Rf htmlcanvas examples/html-canvas examples/opengl
 script:
-  - go test -covermode=count -coverprofile=profile.cov .
+  - go test -covermode=count -coverprofile=profile.cov ./...
   - goveralls -coverprofile=profile.cov -service=travis-ci
 

--- a/README.md
+++ b/README.md
@@ -152,13 +152,14 @@ ctx.DrawText(x, y float64, *Text)
 ctx.DrawImage(x, y float64, image.Image, dpm float64)
 
 c.Fit(margin float64)  // resize canvas to fit all elements with a given margin
-c.SaveSVG(filename string)
-c.SaveEPS(filename string)
-c.SavePDF(filename string)
-c.SavePNG(filename string)
-c.SaveJPG(filename string)
-c.SaveGIF(filename string)
-c.WriteImage(dpm float64) *image.RGBA
+
+c.WriteFile(filename string, svg.Writer)
+c.WriteFile(filename string, pdf.Writer)
+c.WriteFile(filename string, eps.Writer)
+c.WriteFile(filename string, rasterizer.PNGWriter(resolution DPMM))
+c.WriteFile(filename string, rasterizer.JPGWriter(resolution DPMM, opts *jpeg.Options))
+c.WriteFile(filename string, rasterizer.GIFWriter(resolution DPMM, opts *gif.Options))
+rasterizer.Draw(c *Canvas, resolution DPMM) *image.RGBA
 ```
 
 Canvas allows to draw either paths, text or images. All positions and sizes are given in millimeters.

--- a/eps/renderer_test.go
+++ b/eps/renderer_test.go
@@ -1,13 +1,15 @@
-package canvas
+package eps
 
 import (
 	"bytes"
 	"testing"
+
+	"github.com/tdewolff/canvas"
 )
 
 func TestEPS(t *testing.T) {
 	w := &bytes.Buffer{}
-	eps := NewEPS(w, 100, 80)
-	eps.setColor(Red)
+	eps := New(w, 100, 80)
+	eps.setColor(canvas.Red)
 	//test.String(t, string(w.Bytes()), "")
 }

--- a/eps/writer.go
+++ b/eps/writer.go
@@ -1,0 +1,15 @@
+package eps
+
+import (
+	"io"
+
+	"github.com/tdewolff/canvas"
+)
+
+// Writer writes the canvas as an EPS file.
+// Be aware that EPS does not support transparency of colors.
+func Writer(w io.Writer, c *canvas.Canvas) error {
+	eps := New(w, c.W, c.H)
+	c.Render(eps)
+	return nil
+}

--- a/examples/document/main.go
+++ b/examples/document/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/rasterizer"
 )
 
 var fontFamily *canvas.FontFamily
@@ -19,7 +20,7 @@ func main() {
 	c := canvas.New(200, 230)
 	ctx := canvas.NewContext(c)
 	draw(ctx)
-	c.SavePNG("out.png", 5.0)
+	c.WriteFile("out.png", rasterizer.PNGWriter(5.0))
 }
 
 var lorem = []string{

--- a/examples/go-chart/main.go
+++ b/examples/go-chart/main.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/golang/freetype/truetype"
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/eps"
+	"github.com/tdewolff/canvas/pdf"
+	"github.com/tdewolff/canvas/rasterizer"
+	"github.com/tdewolff/canvas/svg"
 	"github.com/wcharczuk/go-chart"
 	"github.com/wcharczuk/go-chart/drawing"
 )
@@ -78,19 +82,19 @@ func main() {
 
 	f, _ := os.Create("output.pdf")
 	defer f.Close()
-	graph.Render(canvas.NewGoChart(canvas.OutputPDF), f)
+	graph.Render(canvas.NewGoChart(pdf.Writer), f)
 
 	f, _ = os.Create("output.svg")
 	defer f.Close()
-	graph.Render(canvas.NewGoChart(canvas.OutputSVG), f)
+	graph.Render(canvas.NewGoChart(svg.Writer), f)
 
 	f, _ = os.Create("output.eps")
 	defer f.Close()
-	graph.Render(canvas.NewGoChart(canvas.OutputEPS), f)
+	graph.Render(canvas.NewGoChart(eps.Writer), f)
 
 	f, _ = os.Create("output.png")
 	defer f.Close()
-	graph.Render(canvas.NewGoChart(canvas.OutputPNG), f)
+	graph.Render(canvas.NewGoChart(rasterizer.PNGWriter(1.0)), f)
 
 	f, _ = os.Create("target.png")
 	defer f.Close()

--- a/examples/gonum-plot/main.go
+++ b/examples/gonum-plot/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/svg"
 	"gonum.org/v1/plot"
 	"gonum.org/v1/plot/plotter"
 	"gonum.org/v1/plot/vg"
@@ -33,5 +34,5 @@ func main() {
 	gonumCanvas := canvas.NewGonumPlot(c)
 	p.Draw(gonumCanvas)
 
-	c.SaveSVG("output.svg")
+	c.WriteFile("output.svg", svg.Writer)
 }

--- a/examples/graph/main.go
+++ b/examples/graph/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/rasterizer"
 )
 
 var fontFamily *canvas.FontFamily
@@ -24,7 +25,7 @@ func main() {
 	c := canvas.New(140, 110)
 	ctx := canvas.NewContext(c)
 	draw(ctx)
-	c.SavePNG("out.png", 5.0)
+	c.WriteFile("out.png", rasterizer.PNGWriter(5.0))
 }
 
 func draw(c *canvas.Context) {

--- a/examples/map/main.go
+++ b/examples/map/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/paulmach/osm/osmapi"
 	"github.com/paulmach/osm/osmgeojson"
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/rasterizer"
 )
 
 var dejaVuSerif *canvas.FontFamily
@@ -24,7 +25,7 @@ func main() {
 	c := canvas.New(100, 100)
 	ctx := canvas.NewContext(c)
 	draw(ctx)
-	c.SavePNG("out.png", 8.0)
+	c.WriteFile("out.png", rasterizer.PNGWriter(8.0))
 }
 
 func draw(c *canvas.Context) {

--- a/examples/opengl/main.go
+++ b/examples/opengl/main.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package main
 
 import (

--- a/examples/preview/main.go
+++ b/examples/preview/main.go
@@ -7,6 +7,10 @@ import (
 	"os"
 
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/eps"
+	"github.com/tdewolff/canvas/pdf"
+	"github.com/tdewolff/canvas/rasterizer"
+	"github.com/tdewolff/canvas/svg"
 )
 
 var fontFamily *canvas.FontFamily
@@ -24,10 +28,10 @@ func main() {
 
 	////////////////
 
-	c.SaveSVG("out.svg")
-	c.SavePDF("out.pdf")
-	c.SaveEPS("out.eps")
-	c.SavePNG("out.png", 3.2)
+	c.WriteFile("out.svg", svg.Writer)
+	c.WriteFile("out.pdf", pdf.Writer)
+	c.WriteFile("out.eps", eps.Writer)
+	c.WriteFile("out.png", rasterizer.PNGWriter(3.2))
 }
 
 func drawText(c *canvas.Context, x, y float64, face canvas.FontFace, rich *canvas.RichText) {

--- a/examples/stroke/main.go
+++ b/examples/stroke/main.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/rasterizer"
 )
 
 var fontFamily *canvas.FontFamily
@@ -21,7 +22,7 @@ func main() {
 	ctx := canvas.NewContext(c)
 	draw(ctx)
 	c.Fit(1.0)
-	c.SavePNG("out.png", 5.0)
+	c.WriteFile("out.png", rasterizer.PNGWriter(5.0))
 }
 
 func drawStrokedPath(c *canvas.Context, x, y float64, path string, cr canvas.Capper, jr canvas.Joiner) {

--- a/examples/text/main.go
+++ b/examples/text/main.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/rasterizer"
 )
 
 var fontFamily *canvas.FontFamily
@@ -18,7 +19,7 @@ func main() {
 	c := canvas.New(265, 90)
 	ctx := canvas.NewContext(c)
 	draw(ctx)
-	c.SavePNG("out.png", 5.0)
+	c.WriteFile("out.png", rasterizer.PNGWriter(5.0))
 }
 
 func drawText(c *canvas.Context, x, y float64, halign, valign canvas.TextAlign, indent float64) {

--- a/examples/title/main.go
+++ b/examples/title/main.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 
 	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/rasterizer"
 )
 
 var font *canvas.FontFamily
@@ -18,7 +19,7 @@ func main() {
 	c := canvas.New(65, 27)
 	ctx := canvas.NewContext(c)
 	draw(ctx)
-	c.SavePNG("out.png", 5.0)
+	c.WriteFile("out.png", rasterizer.PNGWriter(5.0))
 }
 
 func draw(c *canvas.Context) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/paulmach/orb v0.1.3
 	github.com/paulmach/osm v0.0.1
-	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 // indirect
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/tdewolff/minify/v2 v2.7.1-0.20200112204046-70870d25a935
 	github.com/tdewolff/parse/v2 v2.4.2
 	github.com/tdewolff/test v1.0.6

--- a/htmlcanvas/htmlcanvas.go
+++ b/htmlcanvas/htmlcanvas.go
@@ -1,3 +1,5 @@
+// +build js
+
 package htmlcanvas
 
 import (

--- a/pdf/writer.go
+++ b/pdf/writer.go
@@ -1,0 +1,14 @@
+package pdf
+
+import (
+	"io"
+
+	"github.com/tdewolff/canvas"
+)
+
+// Writer writes the canvas as a PDF file.
+func Writer(w io.Writer, c *canvas.Canvas) error {
+	pdf := canvas.NewPDF(w, c.W, c.H)
+	c.Render(pdf)
+	return pdf.Close()
+}

--- a/rasterizer/writer.go
+++ b/rasterizer/writer.go
@@ -1,0 +1,37 @@
+package rasterizer
+
+import (
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"io"
+
+	"github.com/tdewolff/canvas"
+)
+
+// PNGWriter writes the canvas as a PNG file
+func PNGWriter(resolution canvas.DPMM) canvas.Writer {
+	return func(w io.Writer, c *canvas.Canvas) error {
+		img := Draw(c, resolution)
+		// TODO: optimization: cache img until canvas changes
+		return png.Encode(w, img)
+	}
+}
+
+// JPGWriter writes the canvas as a JPG file
+func JPGWriter(resolution canvas.DPMM, opts *jpeg.Options) canvas.Writer {
+	return func(w io.Writer, c *canvas.Canvas) error {
+		img := Draw(c, resolution)
+		// TODO: optimization: cache img until canvas changes
+		return jpeg.Encode(w, img, opts)
+	}
+}
+
+// GIFWriter writes the canvas as a GIF file
+func GIFWriter(resolution canvas.DPMM, opts *gif.Options) canvas.Writer {
+	return func(w io.Writer, c *canvas.Canvas) error {
+		img := Draw(c, resolution)
+		// TODO: optimization: cache img until canvas changes
+		return gif.Encode(w, img, opts)
+	}
+}

--- a/svg/writer.go
+++ b/svg/writer.go
@@ -1,0 +1,14 @@
+package svg
+
+import (
+	"io"
+
+	"github.com/tdewolff/canvas"
+)
+
+// Writer writes the canvas as a SVG file
+func Writer(w io.Writer, c *canvas.Canvas) error {
+	svg := canvas.NewSVG(w, c.W, c.H)
+	c.Render(svg)
+	return svg.Close()
+}

--- a/tex/writer.go
+++ b/tex/writer.go
@@ -1,0 +1,15 @@
+package tex
+
+import (
+	"io"
+
+	"github.com/tdewolff/canvas"
+)
+
+// Writer writes the canvas as a TeX file using PGF (\usepackage{pgf}).
+// Be aware that TeX/PGF does not support transparency of colors.
+func Writer(w io.Writer, c *canvas.Canvas) error {
+	tex := canvas.NewTeX(w, c.W, c.H)
+	c.Render(tex)
+	return tex.Close()
+}


### PR DESCRIPTION
Related to #24.

I have tried to move the pdf logic into a subpackage, but it revealed to be a non-trivial task since it uses a lot of non-exported structs and fields (Text.lines for instance).

To have a better understanding of how the subpackage structure will feel without having to change any exported stuff, I choose to rather create a `rasterimage` subpackage.

After some error and trial (especially regarding the handling of `go-chart`) here is what I came up with.
```go
c.WriteFile("out.png", rasterimage.PNGWriter(3.2))
```
I think that it feels quite idiomatic (and it removes some duplicated code for the file creation).
Moreover I find this solution to work quite well with the `go-chart` stuff (does not require an extra type):
```go
graph.Render(canvas.NewGoChart(rasterimage.PNGWriter(1.0)), f)
```

What do you think?