### PR TITLE
Fix RenderImage for Bounds not starting at 0,0

### DIFF
--- a/htmlcanvas/htmlcanvas.go
+++ b/htmlcanvas/htmlcanvas.go
@@ -166,11 +166,12 @@ func jsAwait(v js.Value) (result js.Value, ok bool) {
 
 func (r *htmlCanvas) RenderImage(img image.Image, m canvas.Matrix) {
 	size := img.Bounds().Size()
+	sp := img.Bounds().Min // starting point
 	buf := make([]byte, 4*size.X*size.Y)
 	for y := 0; y < size.Y; y++ {
 		for x := 0; x < size.X; x++ {
 			i := (y*size.X + x) * 4
-			r, g, b, a := img.At(x, y).RGBA()
+			r, g, b, a := img.At(sp.X+x, sp.Y+y).RGBA()
 			alpha := float64(a>>8) / 256.0
 			buf[i+0] = byte(float64(r>>8) / alpha)
 			buf[i+1] = byte(float64(g>>8) / alpha)

--- a/pdf.go
+++ b/pdf.go
@@ -941,13 +941,14 @@ func (w *pdfPageWriter) DrawImage(img image.Image, enc ImageEncoding, m Matrix) 
 
 func (w *pdfPageWriter) embedImage(img image.Image, enc ImageEncoding) pdfName {
 	size := img.Bounds().Size()
+	sp := img.Bounds().Min // starting point
 	b := make([]byte, size.X*size.Y*3)
 	bMask := make([]byte, size.X*size.Y)
 	hasMask := false
 	for y := 0; y < size.Y; y++ {
 		for x := 0; x < size.X; x++ {
 			i := (y*size.X + x) * 3
-			R, G, B, A := img.At(x, y).RGBA()
+			R, G, B, A := img.At(sp.X+x, sp.Y+y).RGBA()
 			if A != 0 {
 				b[i+0] = byte((R * 65535 / A) >> 8)
 				b[i+1] = byte((G * 65535 / A) >> 8)

--- a/rasterizer/renderer.go
+++ b/rasterizer/renderer.go
@@ -109,7 +109,7 @@ func (r *Renderer) RenderImage(img image.Image, m canvas.Matrix) {
 	size := img.Bounds().Size()
 	sp := img.Bounds().Min // starting point
 	img2 := image.NewRGBA(image.Rect(0, 0, size.X+margin*2, size.Y+margin*2))
-	draw.Draw(img2, image.Rect(margin, margin, size.X, size.Y), img, sp, draw.Over)
+	draw.Draw(img2, image.Rect(margin, margin, size.X+margin, size.Y+margin), img, sp, draw.Over)
 
 	// draw to destination image
 	// note that we need to correct for the added margin in origin and m

--- a/rasterizer/renderer.go
+++ b/rasterizer/renderer.go
@@ -107,8 +107,9 @@ func (r *Renderer) RenderImage(img image.Image, m canvas.Matrix) {
 	// add transparent margin to image for smooth borders when rotating
 	margin := 4
 	size := img.Bounds().Size()
+	sp := img.Bounds().Min // starting point
 	img2 := image.NewRGBA(image.Rect(0, 0, size.X+margin*2, size.Y+margin*2))
-	draw.Draw(img2, image.Rect(margin, margin, size.X, size.Y), img, image.Point{}, draw.Over)
+	draw.Draw(img2, image.Rect(margin, margin, size.X, size.Y), img, sp, draw.Over)
 
 	// draw to destination image
 	// note that we need to correct for the added margin in origin and m


### PR DESCRIPTION
_Fixes #35_ 

When the `img.Bounds()` did not start at `0,0`, some renderer had issues drawing the image.

Affected (and fixed) renderers: `pdf`, `rasterizer`, `htmlcanvas`
( `svg` was not affected and `eps` and `tex` do not support image rendering)