### PR TITLE
Refactor RenderDecoration for pdf and svg

### DIFF
--- a/pdf.go
+++ b/pdf.go
@@ -192,8 +192,6 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 
 func (r *PDF) RenderText(text *Text, m Matrix) {
 	r.w.StartTextObject()
-	decoPaths := []*Path{}
-	decoColors := []color.RGBA{}
 	for _, line := range text.lines {
 		for _, span := range line.spans {
 			r.w.SetFillColor(span.ff.color)
@@ -222,19 +220,10 @@ func (r *PDF) RenderText(text *Text, m Matrix) {
 			}
 			r.w.WriteText(TJ...)
 		}
-		for _, deco := range line.decos {
-			p := deco.ff.Decorate(deco.x1 - deco.x0)
-			p = p.Transform(Identity.Mul(m).Translate(deco.x0, line.y+deco.ff.voffset))
-			decoPaths = append(decoPaths, p)
-			decoColors = append(decoColors, deco.ff.color)
-		}
 	}
 	r.w.EndTextObject()
-	style := DefaultStyle
-	for i := range decoPaths {
-		style.FillColor = decoColors[i]
-		r.RenderPath(decoPaths[i], style, Identity)
-	}
+
+	text.RenderDecoration(r, m)
 }
 
 func (r *PDF) RenderImage(img image.Image, m Matrix) {

--- a/svg.go
+++ b/svg.go
@@ -308,8 +308,6 @@ func (r *SVG) RenderText(text *Text, m Matrix) {
 	r.writeClasses(r.w)
 	fmt.Fprintf(r.w, `">`)
 
-	decoPaths := []*Path{}
-	decoColors := []color.RGBA{}
 	for _, line := range text.lines {
 		for _, span := range line.spans {
 			fmt.Fprintf(r.w, `<tspan x="%v" y="%v`, num(x0+span.dx), num(y0-line.y-span.ff.voffset))
@@ -325,19 +323,9 @@ func (r *SVG) RenderText(text *Text, m Matrix) {
 			r.writeClasses(r.w)
 			fmt.Fprintf(r.w, `">%s</tspan>`, s)
 		}
-		for _, deco := range line.decos {
-			p := deco.ff.Decorate(deco.x1 - deco.x0)
-			p = p.Transform(Identity.Mul(m).Translate(deco.x0, line.y+deco.ff.voffset))
-			decoPaths = append(decoPaths, p)
-			decoColors = append(decoColors, deco.ff.color)
-		}
 	}
 	fmt.Fprintf(r.w, `</text>`)
-	style := DefaultStyle
-	for i := range decoPaths {
-		style.FillColor = decoColors[i]
-		r.RenderPath(decoPaths[i], style, Identity)
-	}
+	text.RenderDecoration(r, m)
 }
 
 func (r *SVG) RenderImage(img image.Image, m Matrix) {

--- a/text.go
+++ b/text.go
@@ -548,6 +548,21 @@ func (t *Text) ToPaths() ([]*Path, []color.RGBA) {
 	return paths, colors
 }
 
+// RenderDecoration renders the text decorations using the RenderPath method of the Renderer.
+// TODO: check text decoration z-positions when text lines are overlapping https://github.com/tdewolff/canvas/pull/40#pullrequestreview-400951503
+// TODO: check compliance with https://drafts.csswg.org/css-text-decor-4/#text-line-constancy
+func (t *Text) RenderDecoration(r Renderer, m Matrix) {
+	style := DefaultStyle
+	for _, line := range t.lines {
+		for _, deco := range line.decos {
+			p := deco.ff.Decorate(deco.x1 - deco.x0)
+			p = p.Transform(Identity.Mul(m).Translate(deco.x0, line.y+deco.ff.voffset))
+			style.FillColor = deco.ff.color
+			r.RenderPath(p, style, Identity)
+		}
+	}
+}
+
 ////////////////////////////////////////////////////////////////
 
 type decoSpan struct {


### PR DESCRIPTION
First step of #36.

This PR removes the need to export the `decoSpan`, when extracting `pdf` or `svg` to new packages.
It add a `RenderDecoAsPath` method (naming _is_ hard) which is then called with the `r.RenderPath` as a callback: `text.RenderDecoAsPath(r.RenderPath, m)`.

What do you think?