### PR TITLE
extract svg package

### DIFF
--- a/fontface.go
+++ b/fontface.go
@@ -165,9 +165,9 @@ func (family *FontFamily) Face(size float64, col color.Color, style FontStyle, v
 	return FontFace{
 		family:     family,
 		font:       font,
-		size:       size,
-		style:      style,
-		variant:    variant,
+		Size:       size,
+		Style:      style,
+		Variant:    variant,
 		Color:      color.RGBA{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8), uint8(a >> 8)},
 		deco:       deco,
 		Scale:      scale,
@@ -182,9 +182,9 @@ type FontFace struct {
 	family *FontFamily
 	font   *Font
 
-	size    float64
-	style   FontStyle
-	variant FontVariant
+	Size    float64
+	Style   FontStyle
+	Variant FontVariant
 	Color   color.RGBA
 	deco    []FontDecorator
 
@@ -193,12 +193,12 @@ type FontFace struct {
 
 // Equals returns true when two font face are equal. In particular this allows two adjacent text spans that use the same decoration to allow the decoration to span both elements instead of two separately.
 func (ff FontFace) Equals(other FontFace) bool {
-	return ff.font == other.font && ff.size == other.size && ff.style == other.style && ff.variant == other.variant && ff.Color == other.Color && reflect.DeepEqual(ff.deco, other.deco)
+	return ff.font == other.font && ff.Size == other.Size && ff.Style == other.Style && ff.Variant == other.Variant && ff.Color == other.Color && reflect.DeepEqual(ff.deco, other.deco)
 }
 
-// Info returns the font name, size and style.
-func (ff FontFace) Info() (name string, size float64, style FontStyle, variant FontVariant) {
-	return ff.font.name, ff.size, ff.style, ff.variant
+// Name returns the name of the underlying font
+func (ff FontFace) Name() string {
+	return ff.font.name
 }
 
 // FontMetrics contains a number of metrics that define a font face.
@@ -214,9 +214,9 @@ type FontMetrics struct {
 // Metrics returns the font metrics. See https://developer.apple.com/library/archive/documentation/TextFonts/Conceptual/CocoaTextArchitecture/Art/glyph_metrics_2x.png for an explanation of the different metrics.
 func (ff FontFace) Metrics() FontMetrics {
 	buffer := &sfnt.Buffer{}
-	m, _ := ff.font.sfnt.Metrics(buffer, toI26_6(ff.size*ff.Scale), font.HintingNone)
+	m, _ := ff.font.sfnt.Metrics(buffer, toI26_6(ff.Size*ff.Scale), font.HintingNone)
 	return FontMetrics{
-		Size:       ff.size,
+		Size:       ff.Size,
 		LineHeight: math.Abs(fromI26_6(m.Height)),
 		Ascent:     math.Abs(fromI26_6(m.Ascent)),
 		Descent:    math.Abs(fromI26_6(m.Descent)),
@@ -238,7 +238,7 @@ func (ff FontFace) Kerning(rPrev, rNext rune) float64 {
 		return 0.0
 	}
 
-	kern, err := ff.font.sfnt.Kern(buffer, prevIndex, nextIndex, toI26_6(ff.size*ff.Scale), font.HintingNone)
+	kern, err := ff.font.sfnt.Kern(buffer, prevIndex, nextIndex, toI26_6(ff.Size*ff.Scale), font.HintingNone)
 	if err == nil {
 		return fromI26_6(kern)
 	}
@@ -257,12 +257,12 @@ func (ff FontFace) TextWidth(s string) float64 {
 		}
 
 		if i != 0 {
-			kern, err := ff.font.sfnt.Kern(buffer, prevIndex, index, toI26_6(ff.size*ff.Scale), font.HintingNone)
+			kern, err := ff.font.sfnt.Kern(buffer, prevIndex, index, toI26_6(ff.Size*ff.Scale), font.HintingNone)
 			if err == nil {
 				w += fromI26_6(kern)
 			}
 		}
-		advance, err := ff.font.sfnt.GlyphAdvance(buffer, index, toI26_6(ff.size*ff.Scale), font.HintingNone)
+		advance, err := ff.font.sfnt.GlyphAdvance(buffer, index, toI26_6(ff.Size*ff.Scale), font.HintingNone)
 		if err == nil {
 			w += fromI26_6(advance)
 		}
@@ -294,7 +294,7 @@ func (ff FontFace) ToPath(s string) (*Path, float64) {
 			return p, 0.0
 		}
 
-		segments, err := ff.font.sfnt.LoadGlyph(buffer, index, toI26_6(ff.size*ff.Scale), nil)
+		segments, err := ff.font.sfnt.LoadGlyph(buffer, index, toI26_6(ff.Size*ff.Scale), nil)
 		if err != nil {
 			return p, 0.0
 		}
@@ -338,12 +338,12 @@ func (ff FontFace) ToPath(s string) (*Path, float64) {
 		}
 
 		if i != 0 {
-			kern, err := ff.font.sfnt.Kern(buffer, prevIndex, index, toI26_6(ff.size*ff.Scale), font.HintingNone)
+			kern, err := ff.font.sfnt.Kern(buffer, prevIndex, index, toI26_6(ff.Size*ff.Scale), font.HintingNone)
 			if err == nil {
 				x += fromI26_6(kern)
 			}
 		}
-		advance, err := ff.font.sfnt.GlyphAdvance(buffer, index, toI26_6(ff.size*ff.Scale), font.HintingNone)
+		advance, err := ff.font.sfnt.GlyphAdvance(buffer, index, toI26_6(ff.Size*ff.Scale), font.HintingNone)
 		if err == nil {
 			x += fromI26_6(advance)
 		}
@@ -354,24 +354,24 @@ func (ff FontFace) ToPath(s string) (*Path, float64) {
 
 func (ff FontFace) Boldness() int {
 	boldness := 400
-	if ff.style&FontExtraLight == FontExtraLight {
+	if ff.Style&FontExtraLight == FontExtraLight {
 		boldness = 100
-	} else if ff.style&FontLight == FontLight {
+	} else if ff.Style&FontLight == FontLight {
 		boldness = 200
-	} else if ff.style&FontBook == FontBook {
+	} else if ff.Style&FontBook == FontBook {
 		boldness = 300
-	} else if ff.style&FontMedium == FontMedium {
+	} else if ff.Style&FontMedium == FontMedium {
 		boldness = 500
-	} else if ff.style&FontSemibold == FontSemibold {
+	} else if ff.Style&FontSemibold == FontSemibold {
 		boldness = 600
-	} else if ff.style&FontBold == FontBold {
+	} else if ff.Style&FontBold == FontBold {
 		boldness = 700
-	} else if ff.style&FontBlack == FontBlack {
+	} else if ff.Style&FontBlack == FontBlack {
 		boldness = 800
-	} else if ff.style&FontExtraBlack == FontExtraBlack {
+	} else if ff.Style&FontExtraBlack == FontExtraBlack {
 		boldness = 900
 	}
-	if ff.variant&FontSubscript != 0 || ff.variant&FontSuperscript != 0 {
+	if ff.Variant&FontSubscript != 0 || ff.Variant&FontSuperscript != 0 {
 		boldness += 300
 		if 1000 < boldness {
 			boldness = 1000

--- a/fontface_test.go
+++ b/fontface_test.go
@@ -12,18 +12,18 @@ func TestFontFamily(t *testing.T) {
 
 	face := family.Face(12.0*ptPerMm, Black, FontRegular, FontNormal)
 	test.Float(t, face.fauxBold, 0.0)
-	test.T(t, face.boldness(), 400)
+	test.T(t, face.Boldness(), 400)
 
 	face = family.Face(12.0*ptPerMm, Black, FontBold|FontItalic, FontNormal)
 	test.Float(t, face.fauxBold, 0.24)
 	test.Float(t, face.fauxItalic, 0.3)
-	test.T(t, face.boldness(), 700)
+	test.T(t, face.Boldness(), 700)
 
 	face = family.Face(12.0*ptPerMm, Black, FontBold|FontItalic, FontSubscript)
-	test.Float(t, face.voffset, -12.0*0.33)
+	test.Float(t, face.Voffset, -12.0*0.33)
 	test.Float(t, face.fauxBold, 0.48*0.583)
 	test.Float(t, face.fauxItalic, 0.3)
-	test.T(t, face.boldness(), 1000)
+	test.T(t, face.Boldness(), 1000)
 }
 
 func TestFontFace(t *testing.T) {

--- a/path.go
+++ b/path.go
@@ -82,7 +82,7 @@ func (p *Path) Equals(q *Path) bool {
 		return false
 	}
 	for i := 0; i < len(p.d); i++ {
-		if !equal(p.d[i], q.d[i]) {
+		if !Equal(p.d[i], q.d[i]) {
 			return false
 		}
 	}
@@ -119,7 +119,7 @@ func (p *Path) Join(q *Path) *Path {
 		return q
 	}
 
-	if !equal(p.d[len(p.d)-3], q.d[1]) || !equal(p.d[len(p.d)-2], q.d[2]) {
+	if !Equal(p.d[len(p.d)-3], q.d[1]) || !Equal(p.d[len(p.d)-2], q.d[2]) {
 		return p.Append(q)
 	}
 
@@ -187,7 +187,7 @@ func (p *Path) Coords() []Point {
 	for i := 0; i < len(p.d); {
 		cmd := p.d[i]
 		i += cmdLen(cmd)
-		if cmd != closeCmd || !equal(coords[len(coords)-1].X, p.d[i-3]) || !equal(coords[len(coords)-1].Y, p.d[i-2]) {
+		if cmd != closeCmd || !Equal(coords[len(coords)-1].X, p.d[i-3]) || !Equal(coords[len(coords)-1].Y, p.d[i-2]) {
 			coords = append(coords, Point{p.d[i-3], p.d[i-2]})
 		}
 	}
@@ -220,7 +220,7 @@ func (p *Path) LineTo(x, y float64) *Path {
 		if cmdLen(lineToCmd) < len(p.d) {
 			prevStart = Point{p.d[len(p.d)-cmdLen(lineToCmd)-3], p.d[len(p.d)-cmdLen(lineToCmd)-2]}
 		}
-		if equal(end.Sub(start).AngleBetween(start.Sub(prevStart)), 0.0) {
+		if Equal(end.Sub(start).AngleBetween(start.Sub(prevStart)), 0.0) {
 			p.d[len(p.d)-3] = x
 			p.d[len(p.d)-2] = y
 			return p
@@ -243,7 +243,7 @@ func (p *Path) QuadTo(cpx, cpy, x, y float64) *Path {
 	end := Point{x, y}
 	if start.Equals(end) && start.Equals(cp) {
 		return p
-	} else if !start.Equals(end) && equal(end.Sub(start).AngleBetween(cp.Sub(start)), 0.0) && equal(end.Sub(start).AngleBetween(end.Sub(cp)), 0.0) {
+	} else if !start.Equals(end) && Equal(end.Sub(start).AngleBetween(cp.Sub(start)), 0.0) && Equal(end.Sub(start).AngleBetween(end.Sub(cp)), 0.0) {
 		return p.LineTo(end.X, end.Y)
 	}
 
@@ -264,7 +264,7 @@ func (p *Path) CubeTo(cpx1, cpy1, cpx2, cpy2, x, y float64) *Path {
 	end := Point{x, y}
 	if start.Equals(end) && start.Equals(cp1) && start.Equals(cp2) {
 		return p
-	} else if !start.Equals(end) && equal(end.Sub(start).AngleBetween(cp1.Sub(start)), 0.0) && equal(end.Sub(start).AngleBetween(end.Sub(cp1)), 0.0) && equal(end.Sub(start).AngleBetween(cp2.Sub(start)), 0.0) && equal(end.Sub(start).AngleBetween(end.Sub(cp2)), 0.0) {
+	} else if !start.Equals(end) && Equal(end.Sub(start).AngleBetween(cp1.Sub(start)), 0.0) && Equal(end.Sub(start).AngleBetween(end.Sub(cp1)), 0.0) && Equal(end.Sub(start).AngleBetween(cp2.Sub(start)), 0.0) && Equal(end.Sub(start).AngleBetween(end.Sub(cp2)), 0.0) {
 		return p.LineTo(end.X, end.Y)
 	}
 
@@ -287,7 +287,7 @@ func (p *Path) ArcTo(rx, ry, rot float64, large, sweep bool, x, y float64) *Path
 	if start.Equals(end) {
 		return p
 	}
-	if equal(rx, 0.0) || equal(ry, 0.0) {
+	if Equal(rx, 0.0) || Equal(ry, 0.0) {
 		return p.LineTo(end.X, end.Y)
 	}
 
@@ -340,7 +340,7 @@ func (p *Path) Arc(rx, ry, rot, theta0, theta1 float64) *Path {
 		startOpposite := center.Sub(p0)
 		p.ArcTo(rx, ry, rot, large, sweep, startOpposite.X, startOpposite.Y)
 		p.ArcTo(rx, ry, rot, large, sweep, start.X, start.Y)
-		if equal(math.Mod(dtheta, 2.0*math.Pi), 0.0) {
+		if Equal(math.Mod(dtheta, 2.0*math.Pi), 0.0) {
 			return p
 		}
 	}
@@ -357,7 +357,7 @@ func (p *Path) Close() *Path {
 	} else if p.d[len(p.d)-1] == moveToCmd {
 		p.d = p.d[:len(p.d)-cmdLen(moveToCmd)]
 		return p
-	} else if p.d[len(p.d)-1] == lineToCmd && equal(p.d[len(p.d)-3], end.X) && equal(p.d[len(p.d)-2], end.Y) {
+	} else if p.d[len(p.d)-1] == lineToCmd && Equal(p.d[len(p.d)-3], end.X) && Equal(p.d[len(p.d)-2], end.Y) {
 		p.d[len(p.d)-1] = closeCmd
 		p.d[len(p.d)-cmdLen(lineToCmd)] = closeCmd
 		return p
@@ -367,7 +367,7 @@ func (p *Path) Close() *Path {
 		if cmdLen(lineToCmd) < len(p.d) {
 			prevStart = Point{p.d[len(p.d)-cmdLen(lineToCmd)-3], p.d[len(p.d)-cmdLen(lineToCmd)-2]}
 		}
-		if equal(end.Sub(start).AngleBetween(start.Sub(prevStart)), 0.0) {
+		if Equal(end.Sub(start).AngleBetween(start.Sub(prevStart)), 0.0) {
 			p.d[len(p.d)-cmdLen(lineToCmd)] = closeCmd
 			p.d[len(p.d)-3] = end.X
 			p.d[len(p.d)-2] = end.Y
@@ -409,7 +409,7 @@ func (p *Path) simplifyToCoords() []Point {
 				coords = append(coords, coord)
 			}
 			i += cmdLen(cmd)
-			if cmd != closeCmd || !equal(coords[len(coords)-1].X, p.d[i-3]) || !equal(coords[len(coords)-1].Y, p.d[i-2]) {
+			if cmd != closeCmd || !Equal(coords[len(coords)-1].X, p.d[i-3]) || !Equal(coords[len(coords)-1].Y, p.d[i-2]) {
 				coords = append(coords, Point{p.d[i-3], p.d[i-2]})
 			}
 		}
@@ -984,7 +984,7 @@ func (p *Path) SplitAt(ts ...float64) []*Path {
 						q.MoveTo(r0.X, r0.Y)
 						j++
 					}
-					if !equal(t0, 1.0) {
+					if !Equal(t0, 1.0) {
 						q.QuadTo(r1.X, r1.Y, r2.X, r2.Y)
 					}
 					T += dT
@@ -1019,7 +1019,7 @@ func (p *Path) SplitAt(ts ...float64) []*Path {
 						q.MoveTo(r0.X, r0.Y)
 						j++
 					}
-					if !equal(t0, 1.0) {
+					if !Equal(t0, 1.0) {
 						q.CubeTo(r1.X, r1.Y, r2.X, r2.Y, r3.X, r3.Y)
 					}
 					T += dT
@@ -1054,7 +1054,7 @@ func (p *Path) SplitAt(ts ...float64) []*Path {
 						nextLarge = large2
 						j++
 					}
-					if !equal(startTheta, theta2) {
+					if !Equal(startTheta, theta2) {
 						q.ArcTo(rx, ry, phi*180.0/math.Pi, nextLarge, sweep, end.X, end.Y)
 					}
 					T += dT
@@ -1134,7 +1134,7 @@ func dashCanonical(offset float64, d []float64) (float64, []float64) {
 
 	// remove zeros except first and last
 	for i := 1; i < len(d)-1; i++ {
-		if equal(d[i], 0.0) {
+		if Equal(d[i], 0.0) {
 			d[i-1] += d[i+1]
 			d = append(d[:i], d[i+2:]...)
 			i--
@@ -1142,7 +1142,7 @@ func dashCanonical(offset float64, d []float64) (float64, []float64) {
 	}
 
 	// remove first zero, collapse with second and last
-	if equal(d[0], 0.0) {
+	if Equal(d[0], 0.0) {
 		if len(d) < 3 {
 			return 0.0, []float64{0.0}
 		}
@@ -1152,7 +1152,7 @@ func dashCanonical(offset float64, d []float64) (float64, []float64) {
 	}
 
 	// remove last zero, collapse with fist and second to last
-	if equal(d[len(d)-1], 0.0) {
+	if Equal(d[len(d)-1], 0.0) {
 		if len(d) < 3 {
 			return 0.0, []float64{}
 		}
@@ -1163,7 +1163,7 @@ func dashCanonical(offset float64, d []float64) (float64, []float64) {
 
 	// if there are zeros or negatives, don't draw any dashes
 	for i := 0; i < len(d); i++ {
-		if d[i] < 0.0 || equal(d[i], 0.0) {
+		if d[i] < 0.0 || Equal(d[i], 0.0) {
 			return 0.0, []float64{0.0}
 		}
 	}
@@ -1173,7 +1173,7 @@ REPEAT:
 	for len(d)%2 == 0 {
 		mid := len(d) / 2
 		for i := 0; i < mid; i++ {
-			if !equal(d[i], d[mid+i]) {
+			if !Equal(d[i], d[mid+i]) {
 				break REPEAT
 			}
 		}
@@ -1594,11 +1594,11 @@ func (p *Path) ToSVG() string {
 		case lineToCmd:
 			xStart, yStart := x, y
 			x, y = p.d[i+1], p.d[i+2]
-			if equal(x, xStart) && equal(y, yStart) {
+			if Equal(x, xStart) && Equal(y, yStart) {
 				// nothing
-			} else if equal(x, xStart) {
+			} else if Equal(x, xStart) {
 				fmt.Fprintf(&sb, "V%v", num(y))
-			} else if equal(y, yStart) {
+			} else if Equal(y, yStart) {
 				fmt.Fprintf(&sb, "H%v", num(x))
 			} else {
 				fmt.Fprintf(&sb, "L%v %v", num(x), num(y))

--- a/path_intersection.go
+++ b/path_intersection.go
@@ -8,7 +8,7 @@ func intersectionLineLine(a0, a1, b0, b1 Point) (Point, bool) {
 	da := a1.Sub(a0)
 	db := b1.Sub(b0)
 	div := da.PerpDot(db)
-	if equal(div, 0.0) {
+	if Equal(div, 0.0) {
 		return Point{}, false
 	}
 

--- a/path_stroke.go
+++ b/path_stroke.go
@@ -378,7 +378,7 @@ func offsetSegment(p *Path, halfWidth float64, cr Capper, jr Joiner) (*Path, *Pa
 			})
 		case closeCmd:
 			end = Point{p.d[i+1], p.d[i+2]}
-			if !equal(start.X, end.X) || !equal(start.Y, end.Y) {
+			if !Equal(start.X, end.X) || !Equal(start.Y, end.Y) {
 				n := end.Sub(start).Rot90CW().Norm(halfWidth)
 				states = append(states, pathStrokeState{
 					cmd: lineToCmd,
@@ -519,7 +519,7 @@ func closeInnerBends(p *Path, indices []int, closed bool) {
 
 // Offset offsets the path to expand by w and returns a new path. If w is negative it will contract. Path must be closed.
 func (p *Path) Offset(w float64, fillRule FillRule) *Path {
-	if equal(w, 0.0) {
+	if Equal(w, 0.0) {
 		return p
 	}
 

--- a/path_util.go
+++ b/path_util.go
@@ -36,7 +36,7 @@ func ellipseCurvatureRadius(rx, ry float64, sweep bool, theta float64) float64 {
 	dp := ellipseDeriv(rx, ry, 0.0, sweep, theta)
 	ddp := ellipseDeriv2(rx, ry, 0.0, sweep, theta)
 	a := dp.PerpDot(ddp)
-	if equal(a, 0.0) {
+	if Equal(a, 0.0) {
 		return math.NaN()
 	}
 	return math.Pow(dp.X*dp.X+dp.Y*dp.Y, 1.5) / a
@@ -63,7 +63,7 @@ func ellipseLength(rx, ry, theta1, theta2 float64) float64 {
 // when angleFrom with range [0, 2*PI) is bigger than angleTo with range (-2*PI, 4*PI), the ellipse runs clockwise. The angles are from before the ellipse has been stretched and rotated.
 // See https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
 func ellipseToCenter(x1, y1, rx, ry, phi float64, large, sweep bool, x2, y2 float64) (float64, float64, float64, float64) {
-	if equal(x1, x2) && equal(y1, y2) {
+	if Equal(x1, x2) && Equal(y1, y2) {
 		return x1, y1, 0.0, 0.0
 	}
 
@@ -373,7 +373,7 @@ func quadraticBezierLength(p0, p1, p2 Point) float64 {
 	A := 4.0 * a.Dot(a)
 	B := 4.0 * a.Dot(b)
 	C := b.Dot(b)
-	if equal(A, 0.0) {
+	if Equal(A, 0.0) {
 		// p1 is in the middle between p0 and p2, so it is a straight line from p0 to p2
 		return p2.Sub(p0).Length()
 	}
@@ -427,7 +427,7 @@ func cubicBezierCurvatureRadius(p0, p1, p2, p3 Point, t float64) float64 {
 	dp := cubicBezierDeriv(p0, p1, p2, p3, t)
 	ddp := cubicBezierDeriv2(p0, p1, p2, p3, t)
 	a := dp.PerpDot(ddp) // negative when bending right ie. curve is CW at this point
-	if equal(a, 0.0) {
+	if Equal(a, 0.0) {
 		return math.NaN()
 	}
 	return math.Pow(dp.X*dp.X+dp.Y*dp.Y, 1.5) / a
@@ -609,25 +609,25 @@ func findInflectionPointRangeCubicBezier(p0, p1, p2, p3 Point, t, flatness float
 	// then we impose that s(tf) = flatness and find tf
 	// at inflection points however, s2 = 0, so that s(t) = s3*t^3
 
-	if !equal(t, 0.0) {
+	if !Equal(t, 0.0) {
 		_, _, _, _, p0, p1, p2, p3 = cubicBezierSplit(p0, p1, p2, p3, t)
 	}
 	nr := p1.Sub(p0)
 	ns := p3.Sub(p0)
-	if equal(nr.X, 0.0) && equal(nr.Y, 0.0) {
+	if Equal(nr.X, 0.0) && Equal(nr.Y, 0.0) {
 		// if p0=p1, then rn (the velocity at t=0) needs adjustment
 		// nr = lim[t->0](B'(t)) = 3*(p1-p0) + 6*t*((p1-p0)+(p2-p1)) + second order terms of t
 		// if (p1-p0)->0, we use (p2-p1)=(p2-p0)
 		nr = p2.Sub(p0)
 	}
 
-	if equal(nr.X, 0.0) && equal(nr.Y, 0.0) {
+	if Equal(nr.X, 0.0) && Equal(nr.Y, 0.0) {
 		// if rn is still zero, this curve has p0=p1=p2, so it is straight
 		return 0.0, 1.0
 	}
 
 	s3 := math.Abs(ns.X*nr.Y-ns.Y*nr.X) / math.Hypot(nr.X, nr.Y)
-	if equal(s3, 0.0) {
+	if Equal(s3, 0.0) {
 		return 0.0, 1.0 // can approximate whole curve linearly
 	}
 

--- a/pdf.go
+++ b/pdf.go
@@ -194,14 +194,14 @@ func (r *PDF) RenderText(text *Text, m Matrix) {
 	r.w.StartTextObject()
 	for _, line := range text.lines {
 		for _, span := range line.spans {
-			r.w.SetFillColor(span.ff.color)
-			r.w.SetFont(span.ff.font, span.ff.size*span.ff.scale)
-			r.w.SetTextPosition(m.Translate(span.dx, line.y).Shear(span.ff.fauxItalic, 0.0))
-			r.w.SetTextCharSpace(span.glyphSpacing)
+			r.w.SetFillColor(span.Face.Color)
+			r.w.SetFont(span.Face.font, span.Face.size*span.Face.Scale)
+			r.w.SetTextPosition(m.Translate(span.dx, line.y).Shear(span.Face.fauxItalic, 0.0))
+			r.w.SetTextCharSpace(span.GlyphSpacing)
 
-			if 0.0 < span.ff.fauxBold {
+			if 0.0 < span.Face.fauxBold {
 				r.w.SetTextRenderMode(2)
-				fmt.Fprintf(r.w, " %v w", dec(span.ff.fauxBold*2.0))
+				fmt.Fprintf(r.w, " %v w", dec(span.Face.fauxBold*2.0))
 			} else {
 				r.w.SetTextRenderMode(0)
 			}
@@ -211,9 +211,9 @@ func (r *PDF) RenderText(text *Text, m Matrix) {
 			for _, boundary := range span.boundaries {
 				if boundary.kind == wordBoundary || boundary.kind == eofBoundary {
 					j := boundary.pos + boundary.size
-					TJ = append(TJ, span.text[i:j])
+					TJ = append(TJ, span.Text[i:j])
 					if boundary.kind == wordBoundary {
-						TJ = append(TJ, span.wordSpacing)
+						TJ = append(TJ, span.WordSpacing)
 					}
 					i = j
 				}

--- a/pdf.go
+++ b/pdf.go
@@ -816,7 +816,7 @@ func (w *pdfPageWriter) SetTextPosition(m Matrix) {
 		return
 	}
 
-	if equal(m[0][0], w.textPosition[0][0]) && equal(m[0][1], w.textPosition[0][1]) && equal(m[1][0], w.textPosition[1][0]) && equal(m[1][1], w.textPosition[1][1]) {
+	if Equal(m[0][0], w.textPosition[0][0]) && Equal(m[0][1], w.textPosition[0][1]) && Equal(m[1][0], w.textPosition[1][0]) && Equal(m[1][1], w.textPosition[1][1]) {
 		d := w.textPosition.Inv().Dot(Point{m[0][2], m[1][2]})
 		fmt.Fprintf(w, " %v %v Td", dec(d.X), dec(d.Y))
 	} else {
@@ -839,7 +839,7 @@ func (w *pdfPageWriter) SetTextCharSpace(space float64) {
 	if !w.inTextObject {
 		panic("must be in text object")
 	}
-	if !equal(w.textCharSpace, space) {
+	if !Equal(w.textCharSpace, space) {
 		fmt.Fprintf(w, " %v Tc", dec(space))
 		w.textCharSpace = space
 	}

--- a/pdf.go
+++ b/pdf.go
@@ -195,7 +195,7 @@ func (r *PDF) RenderText(text *Text, m Matrix) {
 	for _, line := range text.lines {
 		for _, span := range line.spans {
 			r.w.SetFillColor(span.Face.Color)
-			r.w.SetFont(span.Face.font, span.Face.size*span.Face.Scale)
+			r.w.SetFont(span.Face.font, span.Face.Size*span.Face.Scale)
 			r.w.SetTextPosition(m.Translate(span.dx, line.y).Shear(span.Face.fauxItalic, 0.0))
 			r.w.SetTextCharSpace(span.GlyphSpacing)
 

--- a/shapes.go
+++ b/shapes.go
@@ -6,7 +6,7 @@ import (
 
 // Rectangle returns a rectangle with width w and height h.
 func Rectangle(w, h float64) *Path {
-	if equal(w, 0.0) || equal(h, 0.0) {
+	if Equal(w, 0.0) || Equal(h, 0.0) {
 		return &Path{}
 	}
 
@@ -20,9 +20,9 @@ func Rectangle(w, h float64) *Path {
 
 // RoundedRectangle returns a rectangle with width w and height h with rounded corners of radius r. A negative radius will cast the corners inwards (ie. concave).
 func RoundedRectangle(w, h, r float64) *Path {
-	if equal(w, 0.0) || equal(h, 0.0) {
+	if Equal(w, 0.0) || Equal(h, 0.0) {
 		return &Path{}
-	} else if equal(r, 0.0) {
+	} else if Equal(r, 0.0) {
 		return Rectangle(w, h)
 	}
 
@@ -49,9 +49,9 @@ func RoundedRectangle(w, h, r float64) *Path {
 
 // BeveledRectangle returns a rectangle with width w and height h with beveled corners at distance r from the corner.
 func BeveledRectangle(w, h, r float64) *Path {
-	if equal(w, 0.0) || equal(h, 0.0) {
+	if Equal(w, 0.0) || Equal(h, 0.0) {
 		return &Path{}
-	} else if equal(r, 0.0) {
+	} else if Equal(r, 0.0) {
 		return Rectangle(w, h)
 	}
 
@@ -79,7 +79,7 @@ func Circle(r float64) *Path {
 
 // Ellipse returns an ellipse with radii rx,ry.
 func Ellipse(rx, ry float64) *Path {
-	if equal(rx, 0.0) || equal(ry, 0.0) {
+	if Equal(rx, 0.0) || Equal(ry, 0.0) {
 		return &Path{}
 	}
 
@@ -98,7 +98,7 @@ func RegularPolygon(n int, r float64, up bool) *Path {
 
 // RegularStarPolygon returns a regular star polygon with radius r and rotation rot in degrees. It uses n vertices of density d. This will result in a self-intersection star in counter clockwise direction. If n/2 < d the star will be clockwise and if n and d are not coprime a regular polygon will be obtained, possible with multiple windings. n must be 3 or more and d 2 or more. The up boolean defines whether the first point will point north or not.
 func RegularStarPolygon(n, d int, r float64, up bool) *Path {
-	if n < 3 || d < 1 || n == d*2 || equal(r, 0.0) {
+	if n < 3 || d < 1 || n == d*2 || Equal(r, 0.0) {
 		return &Path{}
 	}
 
@@ -124,7 +124,7 @@ func RegularStarPolygon(n, d int, r float64, up bool) *Path {
 
 // StarPolygon returns a star polygon of n points with alternating radius R and r. The up boolean defines whether the first point (true) or second point (false) will be pointing north.
 func StarPolygon(n int, R, r float64, up bool) *Path {
-	if n < 3 || equal(R, 0.0) || equal(r, 0.0) {
+	if n < 3 || Equal(R, 0.0) || Equal(r, 0.0) {
 		return &Path{}
 	}
 

--- a/svg/renderer.go
+++ b/svg/renderer.go
@@ -217,25 +217,24 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 func (r *SVG) writeFontStyle(ff, ffMain canvas.FontFace) {
 	boldness := ff.Boldness()
 	differences := 0
-	name, size, style, variant := ff.Info()
-	nameMain, sizeMain, styleMain, variantMain := ffMain.Info()
-	if style&canvas.FontItalic != styleMain&canvas.FontItalic {
+
+	if ff.Style&canvas.FontItalic != ffMain.Style&canvas.FontItalic {
 		differences++
 	}
 	if boldness != ffMain.Boldness() {
 		differences++
 	}
-	if variant&canvas.FontSmallcaps != variantMain&canvas.FontSmallcaps {
+	if ff.Variant&canvas.FontSmallcaps != ffMain.Variant&canvas.FontSmallcaps {
 		differences++
 	}
 	if ff.Color != ffMain.Color {
 		differences++
 	}
-	if name != nameMain || size*ff.Scale != sizeMain || differences == 3 {
+	if ff.Name() != ffMain.Name() || ff.Size*ff.Scale != ffMain.Size || differences == 3 {
 		fmt.Fprintf(r.w, `" style="font:`)
 
 		buf := &bytes.Buffer{}
-		if style&canvas.FontItalic != styleMain&canvas.FontItalic {
+		if ff.Style&canvas.FontItalic != ffMain.Style&canvas.FontItalic {
 			fmt.Fprintf(buf, ` italic`)
 		}
 
@@ -243,11 +242,11 @@ func (r *SVG) writeFontStyle(ff, ffMain canvas.FontFace) {
 			fmt.Fprintf(buf, ` %d`, boldness)
 		}
 
-		if variant&canvas.FontSmallcaps != variantMain&canvas.FontSmallcaps {
+		if ff.Variant&canvas.FontSmallcaps != ffMain.Variant&canvas.FontSmallcaps {
 			fmt.Fprintf(buf, ` small-caps`)
 		}
 
-		fmt.Fprintf(buf, ` %vpx %s`, num(size*ff.Scale), name)
+		fmt.Fprintf(buf, ` %vpx %s`, num(ff.Size*ff.Scale), ff.Name())
 		buf.ReadByte()
 		buf.WriteTo(r.w)
 
@@ -259,13 +258,13 @@ func (r *SVG) writeFontStyle(ff, ffMain canvas.FontFace) {
 	} else if 0 < differences {
 		fmt.Fprintf(r.w, `" style="`)
 		buf := &bytes.Buffer{}
-		if style&canvas.FontItalic != styleMain&canvas.FontItalic {
+		if ff.Style&canvas.FontItalic != ffMain.Style&canvas.FontItalic {
 			fmt.Fprintf(buf, `;font-style:italic`)
 		}
 		if boldness != ffMain.Boldness() {
 			fmt.Fprintf(buf, `;font-weight:%d`, boldness)
 		}
-		if variant&canvas.FontSmallcaps != variantMain&canvas.FontSmallcaps {
+		if ff.Variant&canvas.FontSmallcaps != ffMain.Variant&canvas.FontSmallcaps {
 			fmt.Fprintf(buf, `;font-variant:small-caps`)
 		}
 		if ff.Color != ffMain.Color {
@@ -286,7 +285,6 @@ func (r *SVG) RenderText(text *canvas.Text, m canvas.Matrix) {
 	}
 
 	ffMain := text.MostCommonFontFace()
-	nameMain, sizeMain, styleMain, variantMain := ffMain.Info()
 
 	x0, y0 := 0.0, 0.0
 	if m.IsTranslation() {
@@ -297,16 +295,16 @@ func (r *SVG) RenderText(text *canvas.Text, m canvas.Matrix) {
 		fmt.Fprintf(r.w, `<text transform="%s`, m.ToSVG(r.height))
 	}
 	fmt.Fprintf(r.w, `" style="font:`)
-	if styleMain&canvas.FontItalic != 0 {
+	if ffMain.Style&canvas.FontItalic != 0 {
 		fmt.Fprintf(r.w, ` italic`)
 	}
 	if boldness := ffMain.Boldness(); boldness != 400 {
 		fmt.Fprintf(r.w, ` %d`, boldness)
 	}
-	if variantMain&canvas.FontSmallcaps != 0 {
+	if ffMain.Variant&canvas.FontSmallcaps != 0 {
 		fmt.Fprintf(r.w, ` small-caps`)
 	}
-	fmt.Fprintf(r.w, ` %vpx %s`, num(sizeMain*ffMain.Scale), nameMain)
+	fmt.Fprintf(r.w, ` %vpx %s`, num(ffMain.Size*ffMain.Scale), ffMain.Name())
 	if ffMain.Color != canvas.Black {
 		fmt.Fprintf(r.w, `;fill:%v`, canvas.CSSColor(ffMain.Color))
 	}

--- a/svg/renderer.go
+++ b/svg/renderer.go
@@ -1,4 +1,4 @@
-package canvas
+package svg
 
 import (
 	"bytes"
@@ -11,30 +11,32 @@ import (
 	"io"
 	"math"
 	"strings"
+
+	"github.com/tdewolff/canvas"
 )
 
 type SVG struct {
 	w             io.Writer
 	width, height float64
 	embedFonts    bool
-	fonts         map[*Font]bool
+	fonts         map[*canvas.Font]bool
 	maskID        int
-	imgEnc        ImageEncoding
+	imgEnc        canvas.ImageEncoding
 
 	classes []string
 }
 
-// NewSVG creates a scalable vector graphics renderer.
-func NewSVG(w io.Writer, width, height float64) *SVG {
+// New creates a scalable vector graphics (SVG) renderer.
+func New(w io.Writer, width, height float64) *SVG {
 	fmt.Fprintf(w, `<svg version="1.1" width="%vmm" height="%vmm" viewBox="0 0 %v %v" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">`, dec(width), dec(height), dec(width), dec(height))
 	return &SVG{
 		w:          w,
 		width:      width,
 		height:     height,
 		embedFonts: true,
-		fonts:      map[*Font]bool{},
+		fonts:      map[*canvas.Font]bool{},
 		maskID:     0,
-		imgEnc:     Lossless,
+		imgEnc:     canvas.Lossless,
 		classes:    []string{},
 	}
 }
@@ -75,11 +77,11 @@ func (r *SVG) EmbedFonts(embedFonts bool) {
 	r.embedFonts = embedFonts
 }
 
-func (r *SVG) SetImageEncoding(enc ImageEncoding) {
+func (r *SVG) SetImageEncoding(enc canvas.ImageEncoding) {
 	r.imgEnc = enc
 }
 
-func (r *SVG) writeFonts(fonts []*Font) {
+func (r *SVG) writeFonts(fonts []*canvas.Font) {
 	is := []int{}
 	for i, font := range fonts {
 		if _, ok := r.fonts[font]; !ok {
@@ -92,7 +94,7 @@ func (r *SVG) writeFonts(fonts []*Font) {
 		fmt.Fprintf(r.w, "<style>")
 		for _, i := range is {
 			mimetype, raw := fonts[i].Raw()
-			fmt.Fprintf(r.w, "\n@font-face{font-family:'%s';src:url('data:%s;base64,", fonts[i].name, mimetype)
+			fmt.Fprintf(r.w, "\n@font-face{font-family:'%s';src:url('data:%s;base64,", fonts[i].Name(), mimetype)
 			encoder := base64.NewEncoder(base64.StdEncoding, r.w)
 			encoder.Write(raw)
 			encoder.Close()
@@ -106,30 +108,30 @@ func (r *SVG) Size() (float64, float64) {
 	return r.width, r.height
 }
 
-func (r *SVG) RenderPath(path *Path, style Style, m Matrix) {
+func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix) {
 	fill := style.FillColor.A != 0
 	stroke := style.StrokeColor.A != 0 && 0.0 < style.StrokeWidth
 
-	path = path.Transform(Identity.ReflectYAbout(r.height / 2.0).Mul(m))
+	path = path.Transform(canvas.Identity.ReflectYAbout(r.height / 2.0).Mul(m))
 	fmt.Fprintf(r.w, `<path d="%s`, path.ToSVG())
 
 	strokeUnsupported := false
-	if arcs, ok := style.StrokeJoiner.(ArcsJoiner); ok && math.IsNaN(arcs.Limit) {
+	if arcs, ok := style.StrokeJoiner.(canvas.ArcsJoiner); ok && math.IsNaN(arcs.Limit) {
 		strokeUnsupported = true
-	} else if miter, ok := style.StrokeJoiner.(MiterJoiner); ok {
+	} else if miter, ok := style.StrokeJoiner.(canvas.MiterJoiner); ok {
 		if math.IsNaN(miter.Limit) {
 			strokeUnsupported = true
-		} else if _, ok := miter.GapJoiner.(BevelJoiner); !ok {
+		} else if _, ok := miter.GapJoiner.(canvas.BevelJoiner); !ok {
 			strokeUnsupported = true
 		}
 	}
 
 	if !stroke {
 		if fill {
-			if style.FillColor != Black {
-				fmt.Fprintf(r.w, `" fill="%v`, CSSColor(style.FillColor))
+			if style.FillColor != canvas.Black {
+				fmt.Fprintf(r.w, `" fill="%v`, canvas.CSSColor(style.FillColor))
 			}
-			if style.FillRule == EvenOdd {
+			if style.FillRule == canvas.EvenOdd {
 				fmt.Fprintf(r.w, `" fill-rule="evenodd`)
 			}
 		} else {
@@ -138,37 +140,37 @@ func (r *SVG) RenderPath(path *Path, style Style, m Matrix) {
 	} else {
 		b := &strings.Builder{}
 		if fill {
-			if style.FillColor != Black {
-				fmt.Fprintf(b, ";fill:%v", CSSColor(style.FillColor))
+			if style.FillColor != canvas.Black {
+				fmt.Fprintf(b, ";fill:%v", canvas.CSSColor(style.FillColor))
 			}
-			if style.FillRule == EvenOdd {
+			if style.FillRule == canvas.EvenOdd {
 				fmt.Fprintf(b, ";fill-rule:evenodd")
 			}
 		} else {
 			fmt.Fprintf(b, ";fill:none")
 		}
 		if stroke && !strokeUnsupported {
-			fmt.Fprintf(b, `;stroke:%v`, CSSColor(style.StrokeColor))
+			fmt.Fprintf(b, `;stroke:%v`, canvas.CSSColor(style.StrokeColor))
 			if style.StrokeWidth != 1.0 {
 				fmt.Fprintf(b, ";stroke-width:%v", dec(style.StrokeWidth))
 			}
-			if _, ok := style.StrokeCapper.(RoundCapper); ok {
+			if _, ok := style.StrokeCapper.(canvas.RoundCapper); ok {
 				fmt.Fprintf(b, ";stroke-linecap:round")
-			} else if _, ok := style.StrokeCapper.(SquareCapper); ok {
+			} else if _, ok := style.StrokeCapper.(canvas.SquareCapper); ok {
 				fmt.Fprintf(b, ";stroke-linecap:square")
-			} else if _, ok := style.StrokeCapper.(ButtCapper); !ok {
+			} else if _, ok := style.StrokeCapper.(canvas.ButtCapper); !ok {
 				panic("SVG: line cap not support")
 			}
-			if _, ok := style.StrokeJoiner.(BevelJoiner); ok {
+			if _, ok := style.StrokeJoiner.(canvas.BevelJoiner); ok {
 				fmt.Fprintf(b, ";stroke-linejoin:bevel")
-			} else if _, ok := style.StrokeJoiner.(RoundJoiner); ok {
+			} else if _, ok := style.StrokeJoiner.(canvas.RoundJoiner); ok {
 				fmt.Fprintf(b, ";stroke-linejoin:round")
-			} else if arcs, ok := style.StrokeJoiner.(ArcsJoiner); ok && !math.IsNaN(arcs.Limit) {
+			} else if arcs, ok := style.StrokeJoiner.(canvas.ArcsJoiner); ok && !math.IsNaN(arcs.Limit) {
 				fmt.Fprintf(b, ";stroke-linejoin:arcs")
 				if !equal(arcs.Limit, 4.0) {
 					fmt.Fprintf(b, ";stroke-miterlimit:%v", dec(arcs.Limit))
 				}
-			} else if miter, ok := style.StrokeJoiner.(MiterJoiner); ok && !math.IsNaN(miter.Limit) {
+			} else if miter, ok := style.StrokeJoiner.(canvas.MiterJoiner); ok && !math.IsNaN(miter.Limit) {
 				// a miter line join is the default
 				if !equal(miter.Limit*2.0/style.StrokeWidth, 4.0) {
 					fmt.Fprintf(b, ";stroke-miterlimit:%v", dec(miter.Limit*2.0/style.StrokeWidth))
@@ -201,10 +203,10 @@ func (r *SVG) RenderPath(path *Path, style Style, m Matrix) {
 		}
 		path = path.Stroke(style.StrokeWidth, style.StrokeCapper, style.StrokeJoiner)
 		fmt.Fprintf(r.w, `<path d="%s`, path.ToSVG())
-		if style.StrokeColor != Black {
-			fmt.Fprintf(r.w, `" fill="%v`, CSSColor(style.StrokeColor))
+		if style.StrokeColor != canvas.Black {
+			fmt.Fprintf(r.w, `" fill="%v`, canvas.CSSColor(style.StrokeColor))
 		}
-		if style.FillRule == EvenOdd {
+		if style.FillRule == canvas.EvenOdd {
 			fmt.Fprintf(r.w, `" fill-rule="evenodd`)
 		}
 		r.writeClasses(r.w)
@@ -212,76 +214,79 @@ func (r *SVG) RenderPath(path *Path, style Style, m Matrix) {
 	}
 }
 
-func (r *SVG) writeFontStyle(ff, ffMain FontFace) {
-	boldness := ff.boldness()
+func (r *SVG) writeFontStyle(ff, ffMain canvas.FontFace) {
+	boldness := ff.Boldness()
 	differences := 0
-	if ff.style&FontItalic != ffMain.style&FontItalic {
+	name, size, style, variant := ff.Info()
+	nameMain, sizeMain, styleMain, variantMain := ffMain.Info()
+	if style&canvas.FontItalic != styleMain&canvas.FontItalic {
 		differences++
 	}
-	if boldness != ffMain.boldness() {
+	if boldness != ffMain.Boldness() {
 		differences++
 	}
-	if ff.variant&FontSmallcaps != ffMain.variant&FontSmallcaps {
+	if variant&canvas.FontSmallcaps != variantMain&canvas.FontSmallcaps {
 		differences++
 	}
-	if ff.color != ffMain.color {
+	if ff.Color != ffMain.Color {
 		differences++
 	}
-	if ff.font.name != ffMain.font.name || ff.size*ff.scale != ffMain.size || differences == 3 {
+	if name != nameMain || size*ff.Scale != sizeMain || differences == 3 {
 		fmt.Fprintf(r.w, `" style="font:`)
 
 		buf := &bytes.Buffer{}
-		if ff.style&FontItalic != ffMain.style&FontItalic {
+		if style&canvas.FontItalic != styleMain&canvas.FontItalic {
 			fmt.Fprintf(buf, ` italic`)
 		}
 
-		if boldness != ffMain.boldness() {
+		if boldness != ffMain.Boldness() {
 			fmt.Fprintf(buf, ` %d`, boldness)
 		}
 
-		if ff.variant&FontSmallcaps != ffMain.variant&FontSmallcaps {
+		if variant&canvas.FontSmallcaps != variantMain&canvas.FontSmallcaps {
 			fmt.Fprintf(buf, ` small-caps`)
 		}
 
-		fmt.Fprintf(buf, ` %vpx %s`, num(ff.size*ff.scale), ff.font.name)
+		fmt.Fprintf(buf, ` %vpx %s`, num(size*ff.Scale), name)
 		buf.ReadByte()
 		buf.WriteTo(r.w)
 
-		if ff.color != ffMain.color {
-			fmt.Fprintf(r.w, `;fill:%v`, CSSColor(ff.color))
+		if ff.Color != ffMain.Color {
+			fmt.Fprintf(r.w, `;fill:%v`, canvas.CSSColor(ff.Color))
 		}
-	} else if differences == 1 && ff.color != ffMain.color {
-		fmt.Fprintf(r.w, `" fill="%v`, CSSColor(ff.color))
+	} else if differences == 1 && ff.Color != ffMain.Color {
+		fmt.Fprintf(r.w, `" fill="%v`, canvas.CSSColor(ff.Color))
 	} else if 0 < differences {
 		fmt.Fprintf(r.w, `" style="`)
 		buf := &bytes.Buffer{}
-		if ff.style&FontItalic != ffMain.style&FontItalic {
+		if style&canvas.FontItalic != styleMain&canvas.FontItalic {
 			fmt.Fprintf(buf, `;font-style:italic`)
 		}
-		if boldness != ffMain.boldness() {
+		if boldness != ffMain.Boldness() {
 			fmt.Fprintf(buf, `;font-weight:%d`, boldness)
 		}
-		if ff.variant&FontSmallcaps != ffMain.variant&FontSmallcaps {
+		if variant&canvas.FontSmallcaps != variantMain&canvas.FontSmallcaps {
 			fmt.Fprintf(buf, `;font-variant:small-caps`)
 		}
-		if ff.color != ffMain.color {
-			fmt.Fprintf(buf, `;fill:%v`, CSSColor(ff.color))
+		if ff.Color != ffMain.Color {
+			fmt.Fprintf(buf, `;fill:%v`, canvas.CSSColor(ff.Color))
 		}
 		buf.ReadByte()
 		buf.WriteTo(r.w)
 	}
 }
 
-func (r *SVG) RenderText(text *Text, m Matrix) {
+func (r *SVG) RenderText(text *canvas.Text, m canvas.Matrix) {
 	if r.embedFonts {
 		r.writeFonts(text.Fonts())
 	}
 
-	if len(text.lines) == 0 || len(text.lines[0].spans) == 0 {
+	if text.Empty() {
 		return
 	}
 
-	ffMain := text.mostCommonFontFace()
+	ffMain := text.MostCommonFontFace()
+	nameMain, sizeMain, styleMain, variantMain := ffMain.Info()
 
 	x0, y0 := 0.0, 0.0
 	if m.IsTranslation() {
@@ -292,46 +297,44 @@ func (r *SVG) RenderText(text *Text, m Matrix) {
 		fmt.Fprintf(r.w, `<text transform="%s`, m.ToSVG(r.height))
 	}
 	fmt.Fprintf(r.w, `" style="font:`)
-	if ffMain.style&FontItalic != 0 {
+	if styleMain&canvas.FontItalic != 0 {
 		fmt.Fprintf(r.w, ` italic`)
 	}
-	if boldness := ffMain.boldness(); boldness != 400 {
+	if boldness := ffMain.Boldness(); boldness != 400 {
 		fmt.Fprintf(r.w, ` %d`, boldness)
 	}
-	if ffMain.variant&FontSmallcaps != 0 {
+	if variantMain&canvas.FontSmallcaps != 0 {
 		fmt.Fprintf(r.w, ` small-caps`)
 	}
-	fmt.Fprintf(r.w, ` %vpx %s`, num(ffMain.size*ffMain.scale), ffMain.font.name)
-	if ffMain.color != Black {
-		fmt.Fprintf(r.w, `;fill:%v`, CSSColor(ffMain.color))
+	fmt.Fprintf(r.w, ` %vpx %s`, num(sizeMain*ffMain.Scale), nameMain)
+	if ffMain.Color != canvas.Black {
+		fmt.Fprintf(r.w, `;fill:%v`, canvas.CSSColor(ffMain.Color))
 	}
 	r.writeClasses(r.w)
 	fmt.Fprintf(r.w, `">`)
 
-	for _, line := range text.lines {
-		for _, span := range line.spans {
-			fmt.Fprintf(r.w, `<tspan x="%v" y="%v`, num(x0+span.dx), num(y0-line.y-span.ff.voffset))
-			if span.wordSpacing > 0.0 {
-				fmt.Fprintf(r.w, `" word-spacing="%v`, num(span.wordSpacing))
-			}
-			if span.glyphSpacing > 0.0 {
-				fmt.Fprintf(r.w, `" letter-spacing="%v`, num(span.glyphSpacing))
-			}
-			r.writeFontStyle(span.ff, ffMain)
-			s := span.text
-			s = strings.ReplaceAll(s, `"`, `&quot;`)
-			r.writeClasses(r.w)
-			fmt.Fprintf(r.w, `">%s</tspan>`, s)
+	text.WalkSpans(func(y, dx float64, span canvas.TextSpan) {
+		fmt.Fprintf(r.w, `<tspan x="%v" y="%v`, num(x0+dx), num(y0-y-span.Face.Voffset))
+		if span.WordSpacing > 0.0 {
+			fmt.Fprintf(r.w, `" word-spacing="%v`, num(span.WordSpacing))
 		}
-	}
+		if span.GlyphSpacing > 0.0 {
+			fmt.Fprintf(r.w, `" letter-spacing="%v`, num(span.GlyphSpacing))
+		}
+		r.writeFontStyle(span.Face, ffMain)
+		s := span.Text
+		s = strings.ReplaceAll(s, `"`, `&quot;`)
+		r.writeClasses(r.w)
+		fmt.Fprintf(r.w, `">%s</tspan>`, s)
+	})
 	fmt.Fprintf(r.w, `</text>`)
 	text.RenderDecoration(r, m)
 }
 
-func (r *SVG) RenderImage(img image.Image, m Matrix) {
+func (r *SVG) RenderImage(img image.Image, m canvas.Matrix) {
 	refMask := ""
 	mimetype := "image/png"
-	if r.imgEnc == Lossy {
+	if r.imgEnc == canvas.Lossy {
 		mimetype = "image/jpg"
 		if opaqueImg, ok := img.(interface{ Opaque() bool }); !ok || !opaqueImg.Opaque() {
 			hasMask := false

--- a/svg/renderer.go
+++ b/svg/renderer.go
@@ -167,12 +167,12 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 				fmt.Fprintf(b, ";stroke-linejoin:round")
 			} else if arcs, ok := style.StrokeJoiner.(canvas.ArcsJoiner); ok && !math.IsNaN(arcs.Limit) {
 				fmt.Fprintf(b, ";stroke-linejoin:arcs")
-				if !equal(arcs.Limit, 4.0) {
+				if !canvas.Equal(arcs.Limit, 4.0) {
 					fmt.Fprintf(b, ";stroke-miterlimit:%v", dec(arcs.Limit))
 				}
 			} else if miter, ok := style.StrokeJoiner.(canvas.MiterJoiner); ok && !math.IsNaN(miter.Limit) {
 				// a miter line join is the default
-				if !equal(miter.Limit*2.0/style.StrokeWidth, 4.0) {
+				if !canvas.Equal(miter.Limit*2.0/style.StrokeWidth, 4.0) {
 					fmt.Fprintf(b, ";stroke-miterlimit:%v", dec(miter.Limit*2.0/style.StrokeWidth))
 				}
 			} else {

--- a/svg/renderer_test.go
+++ b/svg/renderer_test.go
@@ -1,4 +1,4 @@
-package canvas
+package svg
 
 import (
 	"testing"

--- a/svg/util.go
+++ b/svg/util.go
@@ -9,11 +9,6 @@ import (
 	"github.com/tdewolff/minify/v2"
 )
 
-// equal returns true if a and b are equal with tolerance Epsilon.
-func equal(a, b float64) bool {
-	return math.Abs(a-b) < canvas.Epsilon
-}
-
 ////////////////////////////////////////////////////////////////
 
 type num float64

--- a/svg/util.go
+++ b/svg/util.go
@@ -1,0 +1,42 @@
+package svg
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/minify/v2"
+)
+
+// equal returns true if a and b are equal with tolerance Epsilon.
+func equal(a, b float64) bool {
+	return math.Abs(a-b) < canvas.Epsilon
+}
+
+////////////////////////////////////////////////////////////////
+
+type num float64
+
+func (f num) String() string {
+	s := fmt.Sprintf("%.*g", canvas.Precision, f)
+	if num(math.MaxInt32) < f || f < num(math.MinInt32) {
+		if i := strings.IndexAny(s, ".eE"); i == -1 {
+			s += ".0"
+		}
+	}
+	return string(minify.Number([]byte(s), canvas.Precision))
+}
+
+type dec float64
+
+func (f dec) String() string {
+	s := fmt.Sprintf("%.*f", canvas.Precision, f)
+	s = string(minify.Decimal([]byte(s), canvas.Precision))
+	if dec(math.MaxInt32) < f || f < dec(math.MinInt32) {
+		if i := strings.IndexByte(s, '.'); i == -1 {
+			s += ".0"
+		}
+	}
+	return s
+}

--- a/svg/writer.go
+++ b/svg/writer.go
@@ -8,7 +8,7 @@ import (
 
 // Writer writes the canvas as a SVG file
 func Writer(w io.Writer, c *canvas.Canvas) error {
-	svg := canvas.NewSVG(w, c.W, c.H)
+	svg := New(w, c.W, c.H)
 	c.Render(svg)
 	return svg.Close()
 }

--- a/text.go
+++ b/text.go
@@ -489,9 +489,9 @@ func (t *Text) MostCommonFontFace() FontFace {
 	for _, line := range t.lines {
 		for _, span := range line.spans {
 			families[span.Face.family]++
-			sizes[span.Face.size]++
-			styles[span.Face.style]++
-			variants[span.Face.variant]++
+			sizes[span.Face.Size]++
+			styles[span.Face.Style]++
+			variants[span.Face.Variant]++
 			colors[span.Face.Color]++
 		}
 	}

--- a/text.go
+++ b/text.go
@@ -540,10 +540,10 @@ func (t *Text) ToPaths() ([]*Path, []color.RGBA) {
 			colors = append(colors, col)
 		}
 		for _, deco := range line.decos {
-			p := deco.ff.Decorate(deco.x1 - deco.x0)
+			p := deco.face.Decorate(deco.x1 - deco.x0)
 			p = p.Translate(deco.x0, line.y)
 			paths = append(paths, p)
-			colors = append(colors, deco.ff.Color)
+			colors = append(colors, deco.face.Color)
 		}
 	}
 	return paths, colors
@@ -556,9 +556,9 @@ func (t *Text) RenderDecoration(r Renderer, m Matrix) {
 	style := DefaultStyle
 	for _, line := range t.lines {
 		for _, deco := range line.decos {
-			p := deco.ff.Decorate(deco.x1 - deco.x0)
-			p = p.Transform(Identity.Mul(m).Translate(deco.x0, line.y+deco.ff.Voffset))
-			style.FillColor = deco.ff.Color
+			p := deco.face.Decorate(deco.x1 - deco.x0)
+			p = p.Transform(Identity.Mul(m).Translate(deco.x0, line.y+deco.face.Voffset))
+			style.FillColor = deco.face.Color
 			r.RenderPath(p, style, Identity)
 		}
 	}
@@ -575,7 +575,7 @@ func (t *Text) WalkSpans(cb func(y, dx float64, span TextSpan)) {
 ////////////////////////////////////////////////////////////////
 
 type decoSpan struct {
-	ff     FontFace
+	face   FontFace
 	x0, x1 float64
 }
 

--- a/text_test.go
+++ b/text_test.go
@@ -123,7 +123,7 @@ func TestRichText(t *testing.T) {
 	test.T(t, len(text.lines), 2)
 	test.Float(t, text.lines[0].spans[0].dx, 0.0)
 	test.Float(t, text.lines[0].spans[0].width, 75.0)
-	test.Float(t, text.lines[0].spans[0].glyphSpacing, (75.0-22.75-3.8125-MaxWordSpacing*face.Metrics().XHeight-22.75)/4)
+	test.Float(t, text.lines[0].spans[0].GlyphSpacing, (75.0-22.75-3.8125-MaxWordSpacing*face.Metrics().XHeight-22.75)/4)
 	test.Float(t, text.lines[1].spans[0].dx, 0.0)
 	test.Float(t, text.lines[1].spans[0].width, 45.5) // cannot stretch in any reasonable way
 
@@ -136,7 +136,7 @@ func TestRichText(t *testing.T) {
 	rt.Add(face, "mm\u200bmm \r\nmm")
 	text = rt.ToText(30.0, 50.0, Left, Top, 0.0, 0.0) // wrap at word break
 	test.T(t, len(text.lines), 3)
-	test.T(t, text.lines[0].spans[0].text, "mm-")
+	test.T(t, text.lines[0].spans[0].Text, "mm-")
 
 	rt = NewRichText()
 	rt.Add(face, "\u200bmm")

--- a/util.go
+++ b/util.go
@@ -17,8 +17,8 @@ var Epsilon = 1e-10
 // Precision is the number of significant digits at which floating point value will be printed to output formats.
 var Precision = 8
 
-// equal returns true if a and b are equal with tolerance Epsilon.
-func equal(a, b float64) bool {
+// Equal returns true if a and b are Equal with tolerance Epsilon.
+func Equal(a, b float64) bool {
 	return math.Abs(a-b) < Epsilon
 }
 
@@ -134,7 +134,7 @@ func (p Point) IsZero() bool {
 
 // Equals returns true if P and Q are equal with tolerance Epsilon.
 func (p Point) Equals(q Point) bool {
-	return equal(p.X, q.X) && equal(p.Y, q.Y)
+	return Equal(p.X, q.X) && Equal(p.Y, q.Y)
 }
 
 // Neg negates x and y.
@@ -214,7 +214,7 @@ func (p Point) AngleBetween(q Point) float64 {
 // Norm normalized OP to be of given length.
 func (p Point) Norm(length float64) Point {
 	d := p.Length()
-	if equal(d, 0.0) {
+	if Equal(d, 0.0) {
 		return Point{}
 	}
 	return Point{p.X / d * length, p.Y / d * length}
@@ -239,7 +239,7 @@ type Rect struct {
 
 // Equals returns true if rectangles are equal with tolerance Epsilon.
 func (r Rect) Equals(q Rect) bool {
-	return equal(r.X, q.X) && equal(r.Y, q.Y) && equal(r.W, q.W) && equal(r.H, q.H)
+	return Equal(r.X, q.X) && Equal(r.Y, q.Y) && Equal(r.W, q.W) && Equal(r.H, q.H)
 }
 
 // Move translates the rect.
@@ -400,7 +400,7 @@ func (m Matrix) Det() float64 {
 // Inv returns the matrix inverse.
 func (m Matrix) Inv() Matrix {
 	det := m.Det()
-	if equal(det, 0.0) {
+	if Equal(det, 0.0) {
 		panic("determinant of affine transformation matrix is zero")
 	}
 	return Matrix{{
@@ -416,7 +416,7 @@ func (m Matrix) Inv() Matrix {
 
 // Eigen returns the matrix eigenvalues and eigenvectors. The first eigenvalue is related to the first eigenvector, and so for the second pair. Eigenvectors are normalized.
 func (m Matrix) Eigen() (float64, float64, Point, Point) {
-	if equal(m[1][0], 0.0) && equal(m[0][1], 0.0) {
+	if Equal(m[1][0], 0.0) && Equal(m[0][1], 0.0) {
 		return m[0][0], m[1][1], Point{1.0, 0.0}, Point{0.0, 1.0}
 	}
 
@@ -430,10 +430,10 @@ func (m Matrix) Eigen() (float64, float64, Point, Point) {
 
 	// see http://www.math.harvard.edu/archive/21b_fall_04/exhibits/2dmatrices/index.html
 	var v1, v2 Point
-	if !equal(m[1][0], 0.0) {
+	if !Equal(m[1][0], 0.0) {
 		v1 = Point{lambda1 - m[1][1], m[1][0]}.Norm(1.0)
 		v2 = Point{lambda2 - m[1][1], m[1][0]}.Norm(1.0)
-	} else if !equal(m[0][1], 0.0) {
+	} else if !Equal(m[0][1], 0.0) {
 		v1 = Point{m[0][1], lambda1 - m[0][0]}.Norm(1.0)
 		v2 = Point{m[0][1], lambda2 - m[0][0]}.Norm(1.0)
 	}
@@ -459,7 +459,7 @@ func (m Matrix) Decompose() (float64, float64, float64, float64, float64, float6
 	a1, a2 := math.Atan2(G, F), math.Atan2(H, E)
 	theta := (a2 - a1) / 2.0 * 180.0 / math.Pi
 	phi := (a2 + a1) / 2.0 * 180.0 / math.Pi
-	if equal(sx, 1.0) && equal(sy, 1.0) {
+	if Equal(sx, 1.0) && Equal(sy, 1.0) {
 		theta += phi
 		phi = 0.0
 	}
@@ -468,12 +468,12 @@ func (m Matrix) Decompose() (float64, float64, float64, float64, float64, float6
 
 // IsTranslation is true if the matrix consists of only translational components, ie. no rotation, scaling or skew.
 func (m Matrix) IsTranslation() bool {
-	return equal(m[0][0], 1.0) && equal(m[0][1], 0.0) && equal(m[1][0], 0.0) && equal(m[1][1], 1.0)
+	return Equal(m[0][0], 1.0) && Equal(m[0][1], 0.0) && Equal(m[1][0], 0.0) && Equal(m[1][1], 1.0)
 }
 
 // IsRigid is true if the matrix consists of only (proper) rigid transformations, ie. no scaling or skew.
 func (m Matrix) IsRigid() bool {
-	if !equal(m.Det(), 1.0) {
+	if !Equal(m.Det(), 1.0) {
 		return false
 	}
 	invM := m.Inv()
@@ -484,7 +484,7 @@ func (m Matrix) IsRigid() bool {
 
 // Equals returns true if both matrices are equal with a tolerance of Epsilon.
 func (m Matrix) Equals(q Matrix) bool {
-	return equal(m[0][0], q[0][0]) && equal(m[0][1], q[0][1]) && equal(m[1][0], q[1][0]) && equal(m[1][1], q[1][1]) && equal(m[0][2], q[0][2]) && equal(m[1][2], q[1][2])
+	return Equal(m[0][0], q[0][0]) && Equal(m[0][1], q[0][1]) && Equal(m[1][0], q[1][0]) && Equal(m[1][1], q[1][1]) && Equal(m[0][2], q[0][2]) && Equal(m[1][2], q[1][2])
 }
 
 // String returns a string representation of the affine transformation matrix as six values, where [a b c; d e f; g h i] will be written as "a b d e c f" as g, h and i have fixed values (0, 0 and 1 respectively).
@@ -497,16 +497,16 @@ func (m Matrix) ToSVG(h float64) string {
 	tx, ty, theta, sx, sy, phi := m.Decompose()
 
 	s := &strings.Builder{}
-	if !equal(m[0][2], 0.0) || !equal(m[1][2], 0.0) {
+	if !Equal(m[0][2], 0.0) || !Equal(m[1][2], 0.0) {
 		fmt.Fprintf(s, " translate(%v,%v)", dec(tx), dec(h-ty))
 	}
-	if !equal(theta, 0.0) {
+	if !Equal(theta, 0.0) {
 		fmt.Fprintf(s, " rotate(%v)", dec(theta))
 	}
-	if !equal(sx, 1.0) || !equal(sy, 1.0) {
+	if !Equal(sx, 1.0) || !Equal(sy, 1.0) {
 		fmt.Fprintf(s, " scale(%v,%v)", dec(sx), dec(sy))
 	}
-	if !equal(phi, 0.0) {
+	if !Equal(phi, 0.0) {
 		fmt.Fprintf(s, " rotate(%v)", dec(phi))
 	}
 
@@ -567,7 +567,7 @@ func solveQuadraticFormula(a, b, c float64) (float64, float64) {
 // see https://github.com/thelonious/kld-polynomial/blob/development/lib/Polynomial.js
 func solveCubicFormula(a, b, c, d float64) (float64, float64, float64) {
 	x1, x2, x3 := math.NaN(), math.NaN(), math.NaN()
-	if equal(a, 0.0) {
+	if Equal(a, 0.0) {
 		x1, x2 = solveQuadraticFormula(b, c, d)
 	} else {
 		// eliminate a
@@ -578,8 +578,8 @@ func solveCubicFormula(a, b, c, d float64) (float64, float64, float64) {
 		bthird := b / 3.0
 		c0 := d - bthird*(c-2.0*bthird*bthird)
 		c1 := c - b*bthird
-		if equal(c0, 0.0) {
-			if equal(c1, 0.0) {
+		if Equal(c0, 0.0) {
+			if Equal(c1, 0.0) {
 				x1 = 0.0 - bthird
 			} else if c1 < 0.0 {
 				tmp := math.Sqrt(-c1)
@@ -587,7 +587,7 @@ func solveCubicFormula(a, b, c, d float64) (float64, float64, float64) {
 				x2 = tmp - bthird
 				x3 = 0.0 - bthird
 			}
-		} else if equal(c1, 0.0) {
+		} else if Equal(c1, 0.0) {
 			if 0.0 < c0 {
 				x1 = -math.Cbrt(c0) - bthird
 			} else {
@@ -595,7 +595,7 @@ func solveCubicFormula(a, b, c, d float64) (float64, float64, float64) {
 			}
 		} else {
 			delta := -(4.0*c1*c1*c1 + 27.0*c0*c0)
-			if equal(delta, 0.0) {
+			if Equal(delta, 0.0) {
 				delta = 0.0
 			}
 


### PR DESCRIPTION
I added one method (following our discussion in #36):
```go
func (t *Text) WalkSpans(cb func(y, dx float64, span TextSpan)) {
	for _, line := range t.lines {
		for _, span := range line.spans {
			cb(line.y, span.dx, span)
		}
	}
}
```

I previously overlooked a bunch of stuff that need to be exported from the FontFace as well
- color
- scale
- voffset

Actually `FontFace.Info()` does not seem to be used anywhere, I could:
- either expand it to include the 3 properties above
- remove it and export the need properties (and adding a `Name()` property to prevent having to export `Family`)

What do you think?



