### PR TITLE
Extract pdf package

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -7,8 +7,8 @@ import (
 	"os"
 )
 
-const mmPerPt = 0.3527777777777778
-const ptPerMm = 2.8346456692913384
+const mmPerPt = 25.4 / 72
+const ptPerMm = 72 / 25.4
 const mmPerInch = 25.4
 const inchPerMm = 1 / 25.4
 

--- a/font.go
+++ b/font.go
@@ -76,6 +76,7 @@ func (f *Font) UnitsPerEm() float64 {
 }
 
 // Kerning returns the horizontal adjustment for the rune pair. A positive kern means to move the glyphs further apart.
+// Returns 0 if there is an error.
 func (f *Font) Kerning(left, right rune, ppem float64) (float64, error) {
 	var sfntBuffer sfnt.Buffer
 
@@ -89,8 +90,11 @@ func (f *Font) Kerning(left, right rune, ppem float64) (float64, error) {
 	}
 
 	kern, err := f.sfnt.Kern(&sfntBuffer, iLeft, iRight, toI26_6(ppem), font.HintingNone)
+	if err != nil {
+		return 0, err
+	}
 
-	return fromI26_6(kern), err
+	return fromI26_6(kern), nil
 }
 
 func (f *Font) PdfInfo() (Rect, float64, float64, float64, float64, []int) {

--- a/font.go
+++ b/font.go
@@ -70,6 +70,11 @@ func (f *Font) Raw() (string, []byte) {
 	return f.mimetype, f.raw
 }
 
+// UnitsPerEm returns the number of units per em for f.
+func (f *Font) UnitsPerEm() float64 {
+	return float64(f.sfnt.UnitsPerEm())
+}
+
 // Kerning returns the horizontal adjustment for the rune pair. A positive kern means to move the glyphs further apart.
 func (f *Font) Kerning(left, right rune, ppem float64) (float64, error) {
 	var sfntBuffer sfnt.Buffer

--- a/font.go
+++ b/font.go
@@ -97,40 +97,64 @@ func (f *Font) Kerning(left, right rune, ppem float64) (float64, error) {
 	return fromI26_6(kern), nil
 }
 
-func (f *Font) PdfInfo() (Rect, float64, float64, float64, float64, []int) {
+// Bounds returns the union of a Font's glyphs' bounds.
+func (f *Font) Bounds(ppem float64) Rect {
+	rect, err := f.sfnt.Bounds(nil, toI26_6(ppem), font.HintingNone)
+	if err != nil {
+		// never happens in sfnt
+		return Rect{}
+	}
+	x0, y0 := fromI26_6(rect.Min.X), fromI26_6(rect.Min.Y)
+	x1, y1 := fromI26_6(rect.Max.X), fromI26_6(rect.Max.Y)
+	return Rect{x0, y0, x1 - x0, y1 - y0}
+}
+
+// ItalicAngle in counter-clockwise degrees from the vertical. Zero for
+// upright text, negative for text that leans to the right (forward).
+func (f *Font) ItalicAngle() float64 {
+	table := f.sfnt.PostTable()
+	if table == nil {
+		return 0
+	}
+	return table.ItalicAngle
+}
+
+// FontMetrics contains a number of metrics that define a font face.
+// See https://developer.apple.com/library/archive/documentation/TextFonts/Conceptual/CocoaTextArchitecture/Art/glyph_metrics_2x.png for an explanation of the different metrics.
+type FontMetrics struct {
+	LineHeight float64
+	Ascent     float64
+	Descent    float64
+	XHeight    float64
+	CapHeight  float64
+}
+
+// Metrics returns the font metrics.
+func (f *Font) Metrics(ppem float64) FontMetrics {
+	metrics, err := f.sfnt.Metrics(nil, toI26_6(ppem), font.HintingNone)
+	if err != nil {
+		return FontMetrics{}
+	}
+	return FontMetrics{
+		LineHeight: fromI26_6(metrics.Height),
+		Ascent:     fromI26_6(metrics.Ascent),
+		Descent:    fromI26_6(metrics.Descent),
+		XHeight:    fromI26_6(metrics.XHeight),
+		CapHeight:  fromI26_6(metrics.CapHeight),
+	}
+}
+
+func (f *Font) Widths(ppem float64) []float64 {
 	buffer := &sfnt.Buffer{}
-	units := float64(f.sfnt.UnitsPerEm())
-
-	bounds := Rect{}
-	rect, err := f.sfnt.Bounds(buffer, toI26_6(units), font.HintingNone)
-	if err == nil {
-		x0, y0 := fromI26_6(rect.Min.X)*1000.0/units, fromI26_6(rect.Min.Y)*1000.0/units
-		x1, y1 := fromI26_6(rect.Max.X)*1000.0/units, fromI26_6(rect.Max.Y)*1000.0/units
-		bounds = Rect{x0, y0, x1 - x0, y1 - y0}
-	}
-
-	italicAngle := 0.0
-	if f.sfnt.PostTable() != nil {
-		italicAngle = f.sfnt.PostTable().ItalicAngle
-	}
-
-	ascent, descent, capHeight := 0.0, 0.0, 0.0
-	metrics, err := f.sfnt.Metrics(buffer, toI26_6(units), font.HintingNone)
-	if err == nil {
-		ascent = fromI26_6(metrics.Ascent) * 1000.0 / units
-		descent = fromI26_6(metrics.Descent) * 1000.0 / units
-		capHeight = fromI26_6(metrics.CapHeight) * 1000.0 / units
-	}
-
-	widths := []int{}
+	widths := []float64{}
 	for i := 0; i < f.sfnt.NumGlyphs(); i++ {
 		index := sfnt.GlyphIndex(i)
-		advance, err := f.sfnt.GlyphAdvance(buffer, index, toI26_6(units), font.HintingNone)
+		advance, err := f.sfnt.GlyphAdvance(buffer, index, toI26_6(ppem), font.HintingNone)
 		if err == nil {
-			widths = append(widths, int(fromI26_6(advance)*1000.0/units+0.5))
+			widths = append(widths, fromI26_6(advance))
 		}
 	}
-	return bounds, italicAngle, ascent, descent, capHeight, widths
+	return widths
 }
 
 func (f *Font) IndicesOf(s string) []uint16 {

--- a/font_test.go
+++ b/font_test.go
@@ -16,13 +16,16 @@ func TestParseTTF(t *testing.T) {
 	test.Error(t, err)
 	test.That(t, font.sfnt.UnitsPerEm() == 2048)
 
-	bounds, italicAngle, ascent, descent, capHeight, widths := font.PdfInfo()
-	test.T(t, bounds, Rect{-769.53125, -1109.375, 2875, 1456.0546875})
-	test.Float(t, italicAngle, 0)
-	test.Float(t, ascent, 928.22265625)
-	test.Float(t, descent, 235.83984375)
-	test.Float(t, capHeight, -729.00390625)
-	test.T(t, len(widths), 3528)
+	units := font.UnitsPerEm()
+
+	test.T(t, font.Bounds(units), Rect{-1576, -2272, 5888, 2982})
+	test.Float(t, font.ItalicAngle(), 0)
+
+	metrics := font.Metrics(units)
+	test.Float(t, metrics.Ascent*1000/units, 928.22265625)
+	test.Float(t, metrics.Descent*1000/units, 235.83984375)
+	test.Float(t, metrics.CapHeight*1000/units, -729.00390625)
+	test.T(t, len(font.Widths(units)), 3528)
 
 	indices := font.IndicesOf("test")
 	test.T(t, len(indices), 4)

--- a/font_test.go
+++ b/font_test.go
@@ -16,7 +16,7 @@ func TestParseTTF(t *testing.T) {
 	test.Error(t, err)
 	test.That(t, font.sfnt.UnitsPerEm() == 2048)
 
-	bounds, italicAngle, ascent, descent, capHeight, widths := font.pdfInfo()
+	bounds, italicAngle, ascent, descent, capHeight, widths := font.PdfInfo()
 	test.T(t, bounds, Rect{-769.53125, -1109.375, 2875, 1456.0546875})
 	test.Float(t, italicAngle, 0)
 	test.Float(t, ascent, 928.22265625)
@@ -24,7 +24,7 @@ func TestParseTTF(t *testing.T) {
 	test.Float(t, capHeight, -729.00390625)
 	test.T(t, len(widths), 3528)
 
-	indices := font.toIndices("test")
+	indices := font.IndicesOf("test")
 	test.T(t, len(indices), 4)
 }
 

--- a/fontface.go
+++ b/fontface.go
@@ -225,12 +225,9 @@ func (ff FontFace) Metrics() FontMetrics {
 	}
 }
 
-// Kerning returns the kerning between two runes in mm (ie. the adjustment on the advance).
+// Kerning returns the eventual kerning between two runes in mm (ie. the adjustment on the advance).
 func (ff FontFace) Kerning(rPrev, rNext rune) float64 {
-	k, err := ff.Font.Kerning(rPrev, rNext, ff.Size*ff.Scale)
-	if err != nil {
-		return 0
-	}
+	k, _ := ff.Font.Kerning(rPrev, rNext, ff.Size*ff.Scale)
 	return k
 }
 

--- a/fontface.go
+++ b/fontface.go
@@ -201,27 +201,15 @@ func (ff FontFace) Name() string {
 	return ff.Font.name
 }
 
-// FontMetrics contains a number of metrics that define a font face.
-type FontMetrics struct {
-	Size       float64
-	LineHeight float64
-	Ascent     float64
-	Descent    float64
-	XHeight    float64
-	CapHeight  float64
-}
-
 // Metrics returns the font metrics. See https://developer.apple.com/library/archive/documentation/TextFonts/Conceptual/CocoaTextArchitecture/Art/glyph_metrics_2x.png for an explanation of the different metrics.
 func (ff FontFace) Metrics() FontMetrics {
-	buffer := &sfnt.Buffer{}
-	m, _ := ff.Font.sfnt.Metrics(buffer, toI26_6(ff.Size*ff.Scale), font.HintingNone)
+	m := ff.Font.Metrics(ff.Size * ff.Scale)
 	return FontMetrics{
-		Size:       ff.Size,
-		LineHeight: math.Abs(fromI26_6(m.Height)),
-		Ascent:     math.Abs(fromI26_6(m.Ascent)),
-		Descent:    math.Abs(fromI26_6(m.Descent)),
-		XHeight:    math.Abs(fromI26_6(m.XHeight)),
-		CapHeight:  math.Abs(fromI26_6(m.CapHeight)),
+		LineHeight: math.Abs(m.LineHeight),
+		Ascent:     math.Abs(m.Ascent),
+		Descent:    math.Abs(m.Descent),
+		XHeight:    math.Abs(m.XHeight),
+		CapHeight:  math.Abs(m.CapHeight),
 	}
 }
 
@@ -382,8 +370,8 @@ var FontUnderline FontDecorator = underline{}
 type underline struct{}
 
 func (underline) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness
-	y := -ff.Metrics().Size * underlineDistance
+	r := ff.Size * underlineThickness
+	y := -ff.Size * underlineDistance
 
 	p := &Path{}
 	p.MoveTo(0.0, y)
@@ -397,8 +385,8 @@ var FontOverline FontDecorator = overline{}
 type overline struct{}
 
 func (overline) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness
-	y := ff.Metrics().XHeight + ff.Metrics().Size*underlineDistance
+	r := ff.Size * underlineThickness
+	y := ff.Metrics().XHeight + ff.Size*underlineDistance
 
 	dx := ff.FauxItalic * y
 	w += ff.FauxItalic * y
@@ -415,7 +403,7 @@ var FontStrikethrough FontDecorator = strikethrough{}
 type strikethrough struct{}
 
 func (strikethrough) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness
+	r := ff.Size * underlineThickness
 	y := ff.Metrics().XHeight / 2.0
 
 	dx := ff.FauxItalic * y
@@ -433,8 +421,8 @@ var FontDoubleUnderline FontDecorator = doubleUnderline{}
 type doubleUnderline struct{}
 
 func (doubleUnderline) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness
-	y := -ff.Metrics().Size * underlineDistance * 0.75
+	r := ff.Size * underlineThickness
+	y := -ff.Size * underlineDistance * 0.75
 
 	p := &Path{}
 	p.MoveTo(0.0, y)
@@ -450,10 +438,10 @@ var FontDottedUnderline FontDecorator = dottedUnderline{}
 type dottedUnderline struct{}
 
 func (dottedUnderline) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness * 0.8
+	r := ff.Size * underlineThickness * 0.8
 	w -= r
 
-	y := -ff.Metrics().Size * underlineDistance
+	y := -ff.Size * underlineDistance
 	d := 15.0 * underlineThickness
 	n := int((w-r)/d) + 1
 	d = (w - r) / float64(n-1)
@@ -471,8 +459,8 @@ var FontDashedUnderline FontDecorator = dashedUnderline{}
 type dashedUnderline struct{}
 
 func (dashedUnderline) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness
-	y := -ff.Metrics().Size * underlineDistance
+	r := ff.Size * underlineThickness
+	y := -ff.Size * underlineDistance
 	d := 12.0 * underlineThickness
 	n := int(w / (2.0 * d))
 	d = w / float64(2*n-1)
@@ -490,11 +478,11 @@ var FontSineUnderline FontDecorator = sineUnderline{}
 type sineUnderline struct{}
 
 func (sineUnderline) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness
+	r := ff.Size * underlineThickness
 	w -= r
 
-	dh := -ff.Metrics().Size * 0.15
-	y := -ff.Metrics().Size * underlineDistance
+	dh := -ff.Size * 0.15
+	y := -ff.Size * underlineDistance
 	d := 12.0 * underlineThickness
 	n := int(0.5 + w/d)
 	d = (w - r) / float64(n)
@@ -519,12 +507,12 @@ var FontSawtoothUnderline FontDecorator = sawtoothUnderline{}
 type sawtoothUnderline struct{}
 
 func (sawtoothUnderline) Decorate(ff FontFace, w float64) *Path {
-	r := ff.Metrics().Size * underlineThickness
+	r := ff.Size * underlineThickness
 	dx := 0.707 * r
 	w -= 2.0 * dx
 
-	dh := -ff.Metrics().Size * 0.15
-	y := -ff.Metrics().Size * underlineDistance
+	dh := -ff.Size * 0.15
+	y := -ff.Size * underlineDistance
 	d := 8.0 * underlineThickness
 	n := int(0.5 + w/d)
 	d = w / float64(n)

--- a/fontface.go
+++ b/fontface.go
@@ -227,7 +227,10 @@ func (ff FontFace) Metrics() FontMetrics {
 
 // Kerning returns the kerning between two runes in mm (ie. the adjustment on the advance).
 func (ff FontFace) Kerning(rPrev, rNext rune) float64 {
-	k, _ := ff.Font.Kerning(rPrev, rNext, ff.Size*ff.Scale)
+	k, err := ff.Font.Kerning(rPrev, rNext, ff.Size*ff.Scale)
+	if err != nil {
+		return 0
+	}
 	return k
 }
 

--- a/fontface_test.go
+++ b/fontface_test.go
@@ -32,7 +32,7 @@ func TestFontFace(t *testing.T) {
 	face := family.Face(12.0*ptPerMm, Black, FontRegular, FontNormal)
 
 	metrics := face.Metrics()
-	test.Float(t, metrics.Size, 12.0)
+	test.Float(t, face.Size, 12.0)
 	test.Float(t, metrics.LineHeight, 13.96875)
 	test.Float(t, metrics.Ascent, 11.140625)
 	test.Float(t, metrics.Descent, 2.828125)

--- a/fontface_test.go
+++ b/fontface_test.go
@@ -11,18 +11,18 @@ func TestFontFamily(t *testing.T) {
 	family.LoadFontFile("font/DejaVuSerif.ttf", FontRegular)
 
 	face := family.Face(12.0*ptPerMm, Black, FontRegular, FontNormal)
-	test.Float(t, face.fauxBold, 0.0)
+	test.Float(t, face.FauxBold, 0.0)
 	test.T(t, face.Boldness(), 400)
 
 	face = family.Face(12.0*ptPerMm, Black, FontBold|FontItalic, FontNormal)
-	test.Float(t, face.fauxBold, 0.24)
-	test.Float(t, face.fauxItalic, 0.3)
+	test.Float(t, face.FauxBold, 0.24)
+	test.Float(t, face.FauxItalic, 0.3)
 	test.T(t, face.Boldness(), 700)
 
 	face = family.Face(12.0*ptPerMm, Black, FontBold|FontItalic, FontSubscript)
 	test.Float(t, face.Voffset, -12.0*0.33)
-	test.Float(t, face.fauxBold, 0.48*0.583)
-	test.Float(t, face.fauxItalic, 0.3)
+	test.Float(t, face.FauxBold, 0.48*0.583)
+	test.Float(t, face.FauxItalic, 0.3)
 	test.T(t, face.Boldness(), 1000)
 }
 

--- a/pdf/renderer.go
+++ b/pdf/renderer.go
@@ -1,4 +1,4 @@
-package canvas
+package pdf
 
 import (
 	"bytes"
@@ -14,28 +14,27 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tdewolff/canvas"
 	canvasFont "github.com/tdewolff/canvas/font"
-	"golang.org/x/image/font"
-	"golang.org/x/image/font/sfnt"
 )
 
 type PDF struct {
 	w             *pdfPageWriter
 	width, height float64
-	imgEnc        ImageEncoding
+	imgEnc        canvas.ImageEncoding
 }
 
 // NewPDF creates a portable document format renderer.
-func NewPDF(w io.Writer, width, height float64) *PDF {
+func New(w io.Writer, width, height float64) *PDF {
 	return &PDF{
 		w:      newPDFWriter(w).NewPage(width, height),
 		width:  width,
 		height: height,
-		imgEnc: Lossless,
+		imgEnc: canvas.Lossless,
 	}
 }
 
-func (r *PDF) SetImageEncoding(enc ImageEncoding) {
+func (r *PDF) SetImageEncoding(enc canvas.ImageEncoding) {
 	r.imgEnc = enc
 }
 
@@ -63,19 +62,19 @@ func (r *PDF) Size() (float64, float64) {
 	return r.width, r.height
 }
 
-func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
+func (r *PDF) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix) {
 	fill := style.FillColor.A != 0
 	stroke := style.StrokeColor.A != 0 && 0.0 < style.StrokeWidth
 	differentAlpha := fill && stroke && style.FillColor.A != style.StrokeColor.A
 
 	// PDFs don't support the arcs joiner, miter joiner (not clipped), or miter joiner (clipped) with non-bevel fallback
 	strokeUnsupported := false
-	if _, ok := style.StrokeJoiner.(ArcsJoiner); ok {
+	if _, ok := style.StrokeJoiner.(canvas.ArcsJoiner); ok {
 		strokeUnsupported = true
-	} else if miter, ok := style.StrokeJoiner.(MiterJoiner); ok {
+	} else if miter, ok := style.StrokeJoiner.(canvas.MiterJoiner); ok {
 		if math.IsNaN(miter.Limit) {
 			strokeUnsupported = true
-		} else if _, ok := miter.GapJoiner.(BevelJoiner); !ok {
+		} else if _, ok := miter.GapJoiner.(canvas.BevelJoiner); !ok {
 			strokeUnsupported = true
 		}
 	}
@@ -99,7 +98,7 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 			r.w.Write([]byte(" "))
 			r.w.Write([]byte(data))
 			r.w.Write([]byte(" f"))
-			if style.FillRule == EvenOdd {
+			if style.FillRule == canvas.EvenOdd {
 				r.w.Write([]byte("*"))
 			}
 		} else if !fill && stroke {
@@ -115,7 +114,7 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 			} else {
 				r.w.Write([]byte(" S"))
 			}
-			if style.FillRule == EvenOdd {
+			if style.FillRule == canvas.EvenOdd {
 				r.w.Write([]byte("*"))
 			}
 		} else if fill && stroke {
@@ -133,7 +132,7 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 				} else {
 					r.w.Write([]byte(" B"))
 				}
-				if style.FillRule == EvenOdd {
+				if style.FillRule == canvas.EvenOdd {
 					r.w.Write([]byte("*"))
 				}
 			} else {
@@ -141,7 +140,7 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 				r.w.Write([]byte(" "))
 				r.w.Write([]byte(data))
 				r.w.Write([]byte(" f"))
-				if style.FillRule == EvenOdd {
+				if style.FillRule == canvas.EvenOdd {
 					r.w.Write([]byte("*"))
 				}
 
@@ -157,7 +156,7 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 				} else {
 					r.w.Write([]byte(" S"))
 				}
-				if style.FillRule == EvenOdd {
+				if style.FillRule == canvas.EvenOdd {
 					r.w.Write([]byte("*"))
 				}
 			}
@@ -169,7 +168,7 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 			r.w.Write([]byte(" "))
 			r.w.Write([]byte(data))
 			r.w.Write([]byte(" f"))
-			if style.FillRule == EvenOdd {
+			if style.FillRule == canvas.EvenOdd {
 				r.w.Write([]byte("*"))
 			}
 		}
@@ -184,49 +183,44 @@ func (r *PDF) RenderPath(path *Path, style Style, m Matrix) {
 		r.w.Write([]byte(" "))
 		r.w.Write([]byte(path.ToPDF()))
 		r.w.Write([]byte(" f"))
-		if style.FillRule == EvenOdd {
+		if style.FillRule == canvas.EvenOdd {
 			r.w.Write([]byte("*"))
 		}
 	}
 }
 
-func (r *PDF) RenderText(text *Text, m Matrix) {
+func (r *PDF) RenderText(text *canvas.Text, m canvas.Matrix) {
 	r.w.StartTextObject()
-	for _, line := range text.lines {
-		for _, span := range line.spans {
-			r.w.SetFillColor(span.Face.Color)
-			r.w.SetFont(span.Face.font, span.Face.Size*span.Face.Scale)
-			r.w.SetTextPosition(m.Translate(span.dx, line.y).Shear(span.Face.fauxItalic, 0.0))
-			r.w.SetTextCharSpace(span.GlyphSpacing)
 
-			if 0.0 < span.Face.fauxBold {
-				r.w.SetTextRenderMode(2)
-				fmt.Fprintf(r.w, " %v w", dec(span.Face.fauxBold*2.0))
-			} else {
-				r.w.SetTextRenderMode(0)
-			}
+	text.WalkSpans(func(y, dx float64, span canvas.TextSpan) {
+		r.w.SetFillColor(span.Face.Color)
+		r.w.SetFont(span.Face.Font, span.Face.Size*span.Face.Scale)
+		r.w.SetTextPosition(m.Translate(dx, y).Shear(span.Face.FauxItalic, 0.0))
+		r.w.SetTextCharSpace(span.GlyphSpacing)
 
-			i := 0
-			TJ := []interface{}{}
-			for _, boundary := range span.boundaries {
-				if boundary.kind == wordBoundary || boundary.kind == eofBoundary {
-					j := boundary.pos + boundary.size
-					TJ = append(TJ, span.Text[i:j])
-					if boundary.kind == wordBoundary {
-						TJ = append(TJ, span.WordSpacing)
-					}
-					i = j
-				}
-			}
-			r.w.WriteText(TJ...)
+		if 0.0 < span.Face.FauxBold {
+			r.w.SetTextRenderMode(2)
+			fmt.Fprintf(r.w, " %v w", dec(span.Face.FauxBold*2.0))
+		} else {
+			r.w.SetTextRenderMode(0)
 		}
-	}
+
+		TJ := []interface{}{}
+		words := span.Words()
+		for i, w := range words {
+			TJ = append(TJ, w)
+			if i != len(words)-1 {
+				TJ = append(TJ, span.WordSpacing)
+			}
+		}
+		r.w.WriteText(TJ...)
+	})
 	r.w.EndTextObject()
 
 	text.RenderDecoration(r, m)
 }
 
-func (r *PDF) RenderImage(img image.Image, m Matrix) {
+func (r *PDF) RenderImage(img image.Image, m canvas.Matrix) {
 	r.w.DrawImage(img, r.imgEnc, m)
 }
 
@@ -237,7 +231,7 @@ type pdfWriter struct {
 	pos        int
 	objOffsets []int
 
-	fonts    map[*Font]pdfRef
+	fonts    map[*canvas.Font]pdfRef
 	pages    []*pdfPageWriter
 	compress bool
 	title    string
@@ -249,7 +243,7 @@ type pdfWriter struct {
 func newPDFWriter(writer io.Writer) *pdfWriter {
 	w := &pdfWriter{
 		w:          writer,
-		fonts:      map[*Font]pdfRef{},
+		fonts:      map[*canvas.Font]pdfRef{},
 		objOffsets: []int{0, 0, 0}, // catalog, metadata, page tree
 	}
 
@@ -416,7 +410,7 @@ func (w *pdfWriter) writeObject(val interface{}) pdfRef {
 	return pdfRef(len(w.objOffsets))
 }
 
-func (w *pdfWriter) getFont(font *Font) pdfRef {
+func (w *pdfWriter) getFont(font *canvas.Font) pdfRef {
 	if ref, ok := w.fonts[font]; ok {
 		return ref
 	}
@@ -443,7 +437,7 @@ func (w *pdfWriter) getFont(font *Font) pdfRef {
 		cidSubtype = "CIDFontType0"
 	}
 
-	bounds, italicAngle, ascent, descent, capHeight, widths := font.pdfInfo()
+	bounds, italicAngle, ascent, descent, capHeight, widths := font.PdfInfo()
 
 	// shorten glyph widths array
 	DW := widths[0]
@@ -475,7 +469,7 @@ func (w *pdfWriter) getFont(font *Font) pdfRef {
 		W = append(W, i, arr)
 	}
 
-	baseFont := strings.ReplaceAll(font.name, " ", "_")
+	baseFont := strings.ReplaceAll(font.Name(), " ", "_")
 	fontfileRef := w.writeObject(pdfStream{
 		dict: pdfDict{
 			"Subtype": pdfName(ffSubtype),
@@ -598,10 +592,10 @@ type pdfPageWriter struct {
 	lineJoin       int
 	miterLimit     float64
 	dashes         []float64
-	font           *Font
+	font           *canvas.Font
 	fontSize       float64
 	inTextObject   bool
-	textPosition   Matrix
+	textPosition   canvas.Matrix
 	textCharSpace  float64
 	textRenderMode int
 }
@@ -616,8 +610,8 @@ func (w *pdfWriter) NewPage(width, height float64) *pdfPageWriter {
 		resources:      pdfDict{},
 		graphicsStates: map[float64]pdfName{},
 		alpha:          1.0,
-		fillColor:      Black,
-		strokeColor:    Black,
+		fillColor:      canvas.Black,
+		strokeColor:    canvas.Black,
 		lineWidth:      1.0,
 		lineCap:        0,
 		lineJoin:       0,
@@ -626,13 +620,13 @@ func (w *pdfWriter) NewPage(width, height float64) *pdfPageWriter {
 		font:           nil,
 		fontSize:       0.0,
 		inTextObject:   false,
-		textPosition:   Identity,
+		textPosition:   canvas.Identity,
 		textCharSpace:  0.0,
 		textRenderMode: 0,
 	}
 	w.pages = append(w.pages, page)
 
-	m := Identity.Scale(ptPerMm, ptPerMm)
+	m := canvas.Identity.Scale(ptPerMm, ptPerMm)
 	fmt.Fprintf(page, " %v %v %v %v %v %v cm", dec(m[0][0]), dec(m[1][0]), dec(m[0][1]), dec(m[1][1]), dec(m[0][2]), dec(m[1][2]))
 	return page
 }
@@ -706,13 +700,13 @@ func (w *pdfPageWriter) SetLineWidth(lineWidth float64) {
 	}
 }
 
-func (w *pdfPageWriter) SetLineCap(capper Capper) {
+func (w *pdfPageWriter) SetLineCap(capper canvas.Capper) {
 	var lineCap int
-	if _, ok := capper.(ButtCapper); ok {
+	if _, ok := capper.(canvas.ButtCapper); ok {
 		lineCap = 0
-	} else if _, ok := capper.(RoundCapper); ok {
+	} else if _, ok := capper.(canvas.RoundCapper); ok {
 		lineCap = 1
-	} else if _, ok := capper.(SquareCapper); ok {
+	} else if _, ok := capper.(canvas.SquareCapper); ok {
 		lineCap = 2
 	} else {
 		panic("PDF: line cap not support")
@@ -723,14 +717,14 @@ func (w *pdfPageWriter) SetLineCap(capper Capper) {
 	}
 }
 
-func (w *pdfPageWriter) SetLineJoin(joiner Joiner) {
+func (w *pdfPageWriter) SetLineJoin(joiner canvas.Joiner) {
 	var lineJoin int
 	var miterLimit float64
-	if _, ok := joiner.(BevelJoiner); ok {
+	if _, ok := joiner.(canvas.BevelJoiner); ok {
 		lineJoin = 2
-	} else if _, ok := joiner.(RoundJoiner); ok {
+	} else if _, ok := joiner.(canvas.RoundJoiner); ok {
 		lineJoin = 1
-	} else if miter, ok := joiner.(MiterJoiner); ok {
+	} else if miter, ok := joiner.(canvas.MiterJoiner); ok {
 		lineJoin = 0
 		if math.IsNaN(miter.Limit) {
 			panic("PDF: line join not support")
@@ -782,7 +776,7 @@ func (w *pdfPageWriter) SetDashes(dashPhase float64, dashArray []float64) {
 	}
 }
 
-func (w *pdfPageWriter) SetFont(font *Font, size float64) {
+func (w *pdfPageWriter) SetFont(font *canvas.Font, size float64) {
 	if !w.inTextObject {
 		panic("must be in text object")
 	}
@@ -808,7 +802,7 @@ func (w *pdfPageWriter) SetFont(font *Font, size float64) {
 	}
 }
 
-func (w *pdfPageWriter) SetTextPosition(m Matrix) {
+func (w *pdfPageWriter) SetTextPosition(m canvas.Matrix) {
 	if !w.inTextObject {
 		panic("must be in text object")
 	}
@@ -816,8 +810,8 @@ func (w *pdfPageWriter) SetTextPosition(m Matrix) {
 		return
 	}
 
-	if Equal(m[0][0], w.textPosition[0][0]) && Equal(m[0][1], w.textPosition[0][1]) && Equal(m[1][0], w.textPosition[1][0]) && Equal(m[1][1], w.textPosition[1][1]) {
-		d := w.textPosition.Inv().Dot(Point{m[0][2], m[1][2]})
+	if canvas.Equal(m[0][0], w.textPosition[0][0]) && canvas.Equal(m[0][1], w.textPosition[0][1]) && canvas.Equal(m[1][0], w.textPosition[1][0]) && canvas.Equal(m[1][1], w.textPosition[1][1]) {
+		d := w.textPosition.Inv().Dot(canvas.Point{m[0][2], m[1][2]})
 		fmt.Fprintf(w, " %v %v Td", dec(d.X), dec(d.Y))
 	} else {
 		fmt.Fprintf(w, " %v %v %v %v %v %v Tm", dec(m[0][0]), dec(m[1][0]), dec(m[0][1]), dec(m[1][1]), dec(m[0][2]), dec(m[1][2]))
@@ -839,7 +833,7 @@ func (w *pdfPageWriter) SetTextCharSpace(space float64) {
 	if !w.inTextObject {
 		panic("must be in text object")
 	}
-	if !Equal(w.textCharSpace, space) {
+	if !canvas.Equal(w.textCharSpace, space) {
 		fmt.Fprintf(w, " %v Tc", dec(space))
 		w.textCharSpace = space
 	}
@@ -850,7 +844,7 @@ func (w *pdfPageWriter) StartTextObject() {
 		panic("already in text object")
 	}
 	fmt.Fprintf(w, " BT")
-	w.textPosition = Identity
+	w.textPosition = canvas.Identity
 	w.inTextObject = true
 }
 
@@ -870,8 +864,6 @@ func (w *pdfPageWriter) WriteText(TJ ...interface{}) {
 		return
 	}
 
-	units := float64(w.font.sfnt.UnitsPerEm())
-
 	first := true
 	write := func(s string) {
 		if first {
@@ -882,7 +874,7 @@ func (w *pdfPageWriter) WriteText(TJ ...interface{}) {
 		}
 
 		buf := &bytes.Buffer{}
-		indices := w.font.toIndices(s)
+		indices := w.font.IndicesOf(s)
 		binary.Write(buf, binary.BigEndian, indices)
 
 		s = buf.String()
@@ -892,7 +884,6 @@ func (w *pdfPageWriter) WriteText(TJ ...interface{}) {
 		fmt.Fprintf(w, "%s)", s)
 	}
 
-	var sfntBuffer sfnt.Buffer
 	fmt.Fprintf(w, "[")
 	for _, tj := range TJ {
 		switch val := tj.(type) {
@@ -901,15 +892,10 @@ func (w *pdfPageWriter) WriteText(TJ ...interface{}) {
 			var rPrev rune
 			for j, r := range val {
 				if i < j {
-					i0, err0 := w.font.sfnt.GlyphIndex(&sfntBuffer, rPrev)
-					i1, err1 := w.font.sfnt.GlyphIndex(&sfntBuffer, r)
-					if err0 == nil && err1 == nil {
-						kern, err := w.font.sfnt.Kern(&sfntBuffer, i0, i1, toI26_6(units), font.HintingNone)
-						if err == nil && kern != 0.0 {
-							write(val[i:j])
-							fmt.Fprintf(w, " %d", -int(fromI26_6(kern)*1000.0/units+0.5))
-							i = j
-						}
+					if kern, err := w.font.Kerning(rPrev, r, 1000); err == nil && kern != 0 {
+						write(val[i:j])
+						fmt.Fprintf(w, " %d", -int(kern+0.5))
+						i = j
 					}
 				}
 				rPrev = r
@@ -924,15 +910,15 @@ func (w *pdfPageWriter) WriteText(TJ ...interface{}) {
 	fmt.Fprintf(w, "]TJ")
 }
 
-func (w *pdfPageWriter) DrawImage(img image.Image, enc ImageEncoding, m Matrix) {
+func (w *pdfPageWriter) DrawImage(img image.Image, enc canvas.ImageEncoding, m canvas.Matrix) {
 	size := img.Bounds().Size()
 
 	// add clipping path around image for smooth edges when rotating
-	outerRect := Rect{0.0, 0.0, float64(size.X), float64(size.Y)}.Transform(m)
-	bl := m.Dot(Point{0, 0})
-	br := m.Dot(Point{float64(size.X), 0})
-	tl := m.Dot(Point{0, float64(size.Y)})
-	tr := m.Dot(Point{float64(size.X), float64(size.Y)})
+	outerRect := canvas.Rect{0.0, 0.0, float64(size.X), float64(size.Y)}.Transform(m)
+	bl := m.Dot(canvas.Point{0, 0})
+	br := m.Dot(canvas.Point{float64(size.X), 0})
+	tl := m.Dot(canvas.Point{0, float64(size.Y)})
+	tr := m.Dot(canvas.Point{float64(size.X), float64(size.Y)})
 	fmt.Fprintf(w, " q %v %v %v %v re W n", dec(outerRect.X), dec(outerRect.Y), dec(outerRect.W), dec(outerRect.H))
 	fmt.Fprintf(w, " %v %v m %v %v l %v %v l %v %v l h W n", dec(bl.X), dec(bl.Y), dec(tl.X), dec(tl.Y), dec(tr.X), dec(tr.Y), dec(br.X), dec(br.Y))
 
@@ -942,7 +928,7 @@ func (w *pdfPageWriter) DrawImage(img image.Image, enc ImageEncoding, m Matrix) 
 	fmt.Fprintf(w, " %v %v %v %v %v %v cm /%v Do Q", dec(m[0][0]), dec(m[1][0]), dec(m[0][1]), dec(m[1][1]), dec(m[0][2]), dec(m[1][2]), name)
 }
 
-func (w *pdfPageWriter) embedImage(img image.Image, enc ImageEncoding) pdfName {
+func (w *pdfPageWriter) embedImage(img image.Image, enc canvas.ImageEncoding) pdfName {
 	size := img.Bounds().Size()
 	sp := img.Bounds().Min // starting point
 	b := make([]byte, size.X*size.Y*3)

--- a/pdf/renderer.go
+++ b/pdf/renderer.go
@@ -884,6 +884,7 @@ func (w *pdfPageWriter) WriteText(TJ ...interface{}) {
 		fmt.Fprintf(w, "%s)", s)
 	}
 
+	units := w.font.UnitsPerEm()
 	fmt.Fprintf(w, "[")
 	for _, tj := range TJ {
 		switch val := tj.(type) {
@@ -892,9 +893,9 @@ func (w *pdfPageWriter) WriteText(TJ ...interface{}) {
 			var rPrev rune
 			for j, r := range val {
 				if i < j {
-					if kern, err := w.font.Kerning(rPrev, r, 1000); err == nil && kern != 0 {
+					if kern, err := w.font.Kerning(rPrev, r, units); err == nil && kern != 0.0 {
 						write(val[i:j])
-						fmt.Fprintf(w, " %d", -int(kern+0.5))
+						fmt.Fprintf(w, " %d", -int(kern*1000/units+0.5))
 						i = j
 					}
 				}

--- a/pdf/renderer_test.go
+++ b/pdf/renderer_test.go
@@ -1,4 +1,4 @@
-package canvas
+package pdf
 
 import (
 	"bytes"
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tdewolff/canvas"
 	"github.com/tdewolff/test"
 )
 
 func TestPDF(t *testing.T) {
-	c := New(10, 10)
-	c.RenderPath(MustParseSVG("L10 0"), DefaultStyle, Identity)
+	c := canvas.New(10, 10)
+	c.RenderPath(canvas.MustParseSVG("L10 0"), canvas.DefaultStyle, canvas.Identity)
 
 	//	pdfCompress = false
 	//	buf := &bytes.Buffer{}
@@ -49,11 +50,11 @@ func TestPDFPath(t *testing.T) {
 	buf := &bytes.Buffer{}
 	pdf := newPDFWriter(buf).NewPage(210.0, 297.0)
 	pdf.SetAlpha(0.5)
-	pdf.SetFillColor(Red)
-	pdf.SetStrokeColor(Blue)
+	pdf.SetFillColor(canvas.Red)
+	pdf.SetStrokeColor(canvas.Blue)
 	pdf.SetLineWidth(5.0)
-	pdf.SetLineCap(RoundCap)
-	pdf.SetLineJoin(RoundJoin)
+	pdf.SetLineCap(canvas.RoundCap)
+	pdf.SetLineJoin(canvas.RoundJoin)
 	pdf.SetDashes(2.0, []float64{1.0, 2.0, 3.0})
 	test.String(t, pdf.String(), " 2.8346457 0 0 2.8346457 0 0 cm /A0 gs 1 0 0 rg /A1 gs 0 0 1 RG 5 w 1 J 1 j [1 2 3 1 2 3] 2 d")
 }
@@ -88,13 +89,13 @@ func TestPDFImage(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	pdf := newPDFWriter(buf).NewPage(210.0, 297.0)
-	pdf.DrawImage(img, Lossless, Identity)
+	pdf.DrawImage(img, canvas.Lossless, canvas.Identity)
 	test.String(t, pdf.String(), " 2.8346457 0 0 2.8346457 0 0 cm q 0 0 2 2 re W n 0 0 m 0 2 l 2 2 l 2 0 l h W n 2 0 0 2 0 0 cm /Im0 Do Q")
 }
 
 func TestPDFMultipage(t *testing.T) {
 	buf := &bytes.Buffer{}
-	pdf := NewPDF(buf, 210, 297)
+	pdf := New(buf, 210, 297)
 	pdf.NewPage(210, 297)
 	err := pdf.Close()
 	test.Error(t, err)

--- a/pdf/util.go
+++ b/pdf/util.go
@@ -1,0 +1,39 @@
+package pdf
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/minify/v2"
+)
+
+const ptPerMm = 72 / 25.4
+
+////////////////////////////////////////////////////////////////
+
+func float64sEqual(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, f := range a {
+		if f != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type dec float64
+
+func (f dec) String() string {
+	s := fmt.Sprintf("%.*f", canvas.Precision, f)
+	s = string(minify.Decimal([]byte(s), canvas.Precision))
+	if dec(math.MaxInt32) < f || f < dec(math.MinInt32) {
+		if i := strings.IndexByte(s, '.'); i == -1 {
+			s += ".0"
+		}
+	}
+	return s
+}

--- a/pdf/writer.go
+++ b/pdf/writer.go
@@ -8,7 +8,7 @@ import (
 
 // Writer writes the canvas as a PDF file.
 func Writer(w io.Writer, c *canvas.Canvas) error {
-	pdf := canvas.NewPDF(w, c.W, c.H)
+	pdf := New(w, c.W, c.H)
 	c.Render(pdf)
 	return pdf.Close()
 }

--- a/text.go
+++ b/text.go
@@ -85,7 +85,7 @@ func NewTextLine(ff FontFace, s string, halign TextAlign) *Text {
 			i = j
 		}
 	}
-	return &Text{lines, map[*Font]bool{ff.font: true}}
+	return &Text{lines, map[*Font]bool{ff.Font: true}}
 }
 
 // NewTextBox is an advanced text formatter that will calculate text placement based on the setteings. It takes a font face, a string, the width or height of the box (can be zero for no limit), horizontal and vertical alignment (Left, Center, Right, Top, Bottom or Justify), text indentation for the first line and line stretch (percentage to stretch the line based on the line height).
@@ -152,7 +152,7 @@ func (rt *RichText) Add(ff FontFace, s string) *RichText {
 			i = j
 		}
 	}
-	rt.fonts[ff.font] = true
+	rt.fonts[ff.Font] = true
 	return rt
 }
 
@@ -734,6 +734,24 @@ func (span TextSpan) ToPath(width float64) (*Path, *Path, color.RGBA) {
 		rPrev = r
 	}
 	return p, span.Face.Decorate(width), span.Face.Color
+}
+
+// Words returns the text of the span, split on wordBoundaries
+func (span TextSpan) Words() []string {
+	var words []string
+	i := 0
+	for _, boundary := range span.boundaries {
+		if boundary.kind != wordBoundary {
+			continue
+		}
+		j := boundary.pos + boundary.size
+		words = append(words, span.Text[i:j])
+		i = j
+	}
+	if i < len(span.Text) {
+		words = append(words, span.Text[i:])
+	}
+	return words
 }
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
_Closes #36_ 

Apart from the expected stuff (exporting some properties and methods), I took the liberty to do some refactoring:
- `Font.Kerning`: to prevent the export of sfnt (for the pdf)
Since the kerning information is need by the pdf at the `Font` level, I moved the `Kerning` logic of the `FontFace` to the `Font` object.
The pdf rendering computed the Kerning by using `w.font.sfnt.UnitsPerEm()` as `ppem` and then dividing it by the same value and then multiplying it by 1000. As a simplification, I directly compute the Kerning using `1000` as the `ppem`.  **Is this approach an oversimplification?**

- `font.toIndices` => `font.IndicesOf`

- Add a `span.Words` methods. 
```go
// Words returns the text of the span, split on wordBoundaries
func (span TextSpan) Words() []string {
	var words []string
	i := 0
	for _, boundary := range span.boundaries {
		if boundary.kind != wordBoundary {
			continue
		}
		j := boundary.pos + boundary.size
		words = append(words, span.Text[i:j])
		i = j
	}
	if i < len(span.Text) {
		words = append(words, span.Text[i:])
	}
	return words
}
```
I didn't find an elegant way to support Glyph, Word and Sentence splitting. Maybe we can postone this problem when a renderer actually needs it?