### PR TITLE
Refactor into RenderTextAsPath

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -326,6 +326,16 @@ func (c *Context) DrawText(x, y float64, texts ...*Text) {
 	}
 }
 
+// RenderTextAsPath renders the text converted to paths (calling r.RenderPath)
+func RenderTextAsPath(r Renderer, text *Text, m Matrix) {
+	paths, colors := text.ToPaths()
+	for i, path := range paths {
+		style := DefaultStyle
+		style.FillColor = colors[i]
+		r.RenderPath(path, style, m)
+	}
+}
+
 // DrawImage draws an image at position (x,y), using an image encoding (Lossy or Lossless) and DPM (dots-per-millimeter). A higher DPM will draw a smaller image.
 func (c *Context) DrawImage(x, y float64, img image.Image, dpm float64) {
 	if img.Bounds().Size().Eq(image.Point{}) {

--- a/eps/renderer.go
+++ b/eps/renderer.go
@@ -85,12 +85,7 @@ func (r *Renderer) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Ma
 
 func (r *Renderer) RenderText(text *canvas.Text, m canvas.Matrix) {
 	// TODO: (EPS) write text natively
-	paths, colors := text.ToPaths()
-	for i, path := range paths {
-		style := canvas.DefaultStyle
-		style.FillColor = colors[i]
-		r.RenderPath(path, style, m)
-	}
+	canvas.RenderTextAsPath(r, text, m)
 }
 
 func (r *Renderer) RenderImage(img image.Image, m canvas.Matrix) {

--- a/htmlcanvas/htmlcanvas.go
+++ b/htmlcanvas/htmlcanvas.go
@@ -127,12 +127,7 @@ func (r *htmlCanvas) RenderPath(path *canvas.Path, style canvas.Style, m canvas.
 }
 
 func (r *htmlCanvas) RenderText(text *canvas.Text, m canvas.Matrix) {
-	paths, colors := text.ToPaths()
-	for i, path := range paths {
-		style := canvas.DefaultStyle
-		style.FillColor = colors[i]
-		r.RenderPath(path, style, m)
-	}
+	canvas.RenderTextAsPath(r, text, m)
 }
 
 func jsAwait(v js.Value) (result js.Value, ok bool) {

--- a/rasterizer/renderer.go
+++ b/rasterizer/renderer.go
@@ -95,12 +95,7 @@ func (r *Renderer) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Ma
 }
 
 func (r *Renderer) RenderText(text *canvas.Text, m canvas.Matrix) {
-	paths, colors := text.ToPaths()
-	for i, path := range paths {
-		style := canvas.DefaultStyle
-		style.FillColor = colors[i]
-		r.RenderPath(path, style, m)
-	}
+	canvas.RenderTextAsPath(r, text, m)
 }
 
 func (r *Renderer) RenderImage(img image.Image, m canvas.Matrix) {

--- a/tex/renderer.go
+++ b/tex/renderer.go
@@ -156,12 +156,7 @@ func (r *TeX) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 
 func (r *TeX) RenderText(text *canvas.Text, m canvas.Matrix) {
 	// TODO: (TeX) write text natively
-	paths, colors := text.ToPaths()
-	for i, path := range paths {
-		style := canvas.DefaultStyle
-		style.FillColor = colors[i]
-		r.RenderPath(path, style, m)
-	}
+	canvas.RenderTextAsPath(r, text, m)
 }
 
 func (r *TeX) RenderImage(img image.Image, m canvas.Matrix) {


### PR DESCRIPTION
_Closes #55_ 

As suggested into the linked issue, I refactored the unimplemented `RenderText` methods in a `canvas.RenderTextAsPath` method.