### PR TITLE
Warning:  length of some xref entries is not equal to 20 bytes.

### DIFF
--- a/pdf/renderer.go
+++ b/pdf/renderer.go
@@ -573,9 +573,9 @@ func (w *pdfWriter) Close() error {
 	w.write("\nendobj\n")
 
 	xrefOffset := w.pos
-	w.write("xref\n0 %d\n0000000000 65535 f\n", len(w.objOffsets)+1)
+	w.write("xref\n0 %d\n0000000000 65535 f \n", len(w.objOffsets)+1)
 	for _, objOffset := range w.objOffsets {
-		w.write("%010d 00000 n\n", objOffset)
+		w.write("%010d 00000 n \n", objOffset)
 	}
 	w.write("trailer\n")
 	w.writeVal(pdfDict{


### PR DESCRIPTION
`gs -dNOPAUSE -dBATCH -sDEVICE=nullpage document.pdf` was giving the following warning:

>   **** Warning:  length of some xref entries is not equal to 20 bytes.

---

According to the PDF spec:

> If  the  file’s  end-of-line  marker  is  a  single  character (either a carriage return or a line feed), it is preceded by a single space; if  the  marker  is  2  characters  (both  a  carriage  return  and  a  line  feed),  it  is  not  preceded  by  a  space.  Thus,  the  overall  length  of  the  entry  is  always  exactly  20  bytes.

This PR fixes this.