### PR TITLE
Corrects the capitalisation of metadata keywords & adds Creator

### DIFF
--- a/renderers/pdf/pdf.go
+++ b/renderers/pdf/pdf.go
@@ -59,12 +59,13 @@ func (r *PDF) SetImageEncoding(enc canvas.ImageEncoding) {
 	r.opts.ImageEncoding = enc
 }
 
-// SetInfo sets the document's title, subject, keywords, and author.
-func (r *PDF) SetInfo(title, subject, keywords, author string) {
+// SetInfo sets the document's title, subject, keywords, author and creator.
+func (r *PDF) SetInfo(title, subject, keywords, author, creator string) {
 	r.w.pdf.SetTitle(title)
 	r.w.pdf.SetSubject(subject)
 	r.w.pdf.SetKeywords(keywords)
 	r.w.pdf.SetAuthor(author)
+	r.w.pdf.SetCreator(creator)
 }
 
 // NewPage starts adds a new page where further rendering will be written to.

--- a/renderers/pdf/pdf_test.go
+++ b/renderers/pdf/pdf_test.go
@@ -106,3 +106,19 @@ func TestPDFMultipage(t *testing.T) {
 	nbPages := strings.Count(out, "/Type /Page ")
 	test.That(t, nbPages == 2, "expected 2 pages, got", nbPages)
 }
+
+func TestPDFMetadata(t *testing.T) {
+	buf := &bytes.Buffer{}
+	pdf := New(buf, 210, 297, nil)
+	pdf.NewPage(210, 297)
+	pdf.SetInfo("a1", "b2", "c3", "d4", "e5")
+	err := pdf.Close()
+	test.Error(t, err)
+	out := buf.String()
+
+	test.That(t, strings.Contains(out, "/Title (a1)"), `could not find "/Title (a1)" in output`)
+	test.That(t, strings.Contains(out, "/Subject (b2)"), `could not find "/Subject (b2)" in output`)
+	test.That(t, strings.Contains(out, "/Keywords (c3)"), `could not find "/Keywords (c3)" in output`)
+	test.That(t, strings.Contains(out, "/Author (d4)"), `could not find "/Author (d4)" in output`)
+	test.That(t, strings.Contains(out, "/Creator (e5)"), `could not find "/Creator (e5)" in output`)
+}

--- a/renderers/pdf/writer.go
+++ b/renderers/pdf/writer.go
@@ -39,6 +39,7 @@ type pdfWriter struct {
 	subject  string
 	keywords string
 	author   string
+	creator  string
 }
 
 func newPDFWriter(writer io.Writer) *pdfWriter {
@@ -83,6 +84,11 @@ func (w *pdfWriter) SetKeywords(keywords string) {
 // SetAuthor sets the document's author.
 func (w *pdfWriter) SetAuthor(author string) {
 	w.author = author
+}
+
+// SetCreator sets the document's creator.
+func (w *pdfWriter) SetCreator(creator string) {
+	w.creator = creator
 }
 
 func (w *pdfWriter) writeBytes(b []byte) {
@@ -486,6 +492,9 @@ func (w *pdfWriter) Close() error {
 	}
 	if w.author != "" {
 		info["Author"] = w.author
+	}
+	if w.creator != "" {
+		info["Creator"] = w.creator
 	}
 
 	w.objOffsets[1] = w.pos

--- a/renderers/pdf/writer.go
+++ b/renderers/pdf/writer.go
@@ -476,16 +476,16 @@ func (w *pdfWriter) Close() error {
 		"CreationDate": time.Now().Format("D:20060102150405Z0700"),
 	}
 	if w.title != "" {
-		info["title"] = w.title
+		info["Title"] = w.title
 	}
 	if w.subject != "" {
-		info["subject"] = w.subject
+		info["Subject"] = w.subject
 	}
 	if w.keywords != "" {
-		info["keywords"] = w.keywords
+		info["Keywords"] = w.keywords
 	}
 	if w.author != "" {
-		info["author"] = w.author
+		info["Author"] = w.author
 	}
 
 	w.objOffsets[1] = w.pos


### PR DESCRIPTION
* Corrects the capitalisation of metadata keywords
* Adds Creator metadata

See Issue #94.

This is a breaking change:
```go
func (r *PDF) SetInfo(title, subject, keywords, author, creator string)
```
The `creator` parameter is new.