### PR TITLE
Use the underlying *vector.Rasterizer.Draw() fast path when calling canvas.Draw()

### DIFF
--- a/renderers/rasterizer/rasterizer.go
+++ b/renderers/rasterizer/rasterizer.go
@@ -169,14 +169,14 @@ func (r *Rasterizer) RenderPath(path *canvas.Path, style canvas.Style, m canvas.
 		fill = fill.Translate(-float64(x)/dpmm, -float64(y)/dpmm)
 		fill.ToRasterizer(ras, r.resolution)
 		col := r.ColorSpace.ToLinear(style.FillColor)
-		ras.Draw(r, image.Rect(x, size.Y-y, x+w, size.Y-y-h), image.NewUniform(col), image.Point{dx, dy})
+		ras.Draw(r.Image, image.Rect(x, size.Y-y, x+w, size.Y-y-h), image.NewUniform(col), image.Point{dx, dy})
 	}
 	if style.HasStroke() {
 		ras := vector.NewRasterizer(w, h)
 		stroke = stroke.Translate(-float64(x)/dpmm, -float64(y)/dpmm)
 		stroke.ToRasterizer(ras, r.resolution)
 		col := r.ColorSpace.ToLinear(style.StrokeColor)
-		ras.Draw(r, image.Rect(x, size.Y-y, x+w, size.Y-y-h), image.NewUniform(col), image.Point{dx, dy})
+		ras.Draw(r.Image, image.Rect(x, size.Y-y, x+w, size.Y-y-h), image.NewUniform(col), image.Point{dx, dy})
 	}
 }
 


### PR DESCRIPTION
The underlying `*vector.Rasterizer.Draw()` function has a fast path that only applies when two things are true:
1. The src is of type `*image.Uniform`
1. The dst is of type `*image.RGBA`

The Rasterizer in the present package wraps a draw.Image of type `*image.RGBA`, but is not, itself, an `*image.RGBA`. Therefore, it gets shunted down the slow path.

This commit instead passes the `Rasterizer.Image` directly to the call to `*vector.Rasterizer.Draw()`, which allows the fast path to be used.

In my experiments with drawing a few hundred large (> 500 x 500px) images with `go 1.18`, this reduced the time spent on `*vector.Rasterizer.Draw()` calls from 80 seconds to 40 seconds. The call path now routes through `vector (*Rasterizer) rasterizeDstRGBASrcUniformOpOver` instead of the generic and slower `vector (*Rasterizer) rasterizeOpOver`.

(This may be related to #47 .)