### PR TITLE
Replace uses of path.Segments() with path.Scanner()

### DIFF
--- a/renderers/gio/gio.go
+++ b/renderers/gio/gio.go
@@ -88,19 +88,19 @@ func (r *Gio) renderPath(path *canvas.Path, col color.RGBA) {
 
 	p := clip.Path{}
 	p.Begin(r.ops)
-	for _, seg := range path.Segments() {
-		switch seg.Cmd {
+	for scanner := path.Scanner(); scanner.Scan(); {
+		switch scanner.Cmd() {
 		case canvas.MoveToCmd:
-			p.MoveTo(r.point(seg.End))
+			p.MoveTo(r.point(scanner.End()))
 		case canvas.LineToCmd:
-			p.LineTo(r.point(seg.End))
+			p.LineTo(r.point(scanner.End()))
 		case canvas.QuadToCmd:
-			p.QuadTo(r.point(seg.CP1()), r.point(seg.End))
+			p.QuadTo(r.point(scanner.CP1()), r.point(scanner.End()))
 		case canvas.CubeToCmd:
-			p.CubeTo(r.point(seg.CP1()), r.point(seg.CP2()), r.point(seg.End))
+			p.CubeTo(r.point(scanner.CP1()), r.point(scanner.CP2()), r.point(scanner.End()))
 		case canvas.ArcToCmd:
 			// TODO: ArcTo
-			p.LineTo(r.point(seg.End))
+			p.LineTo(r.point(scanner.End()))
 		case canvas.CloseCmd:
 			p.Close()
 		}

--- a/renderers/htmlcanvas/htmlcanvas.go
+++ b/renderers/htmlcanvas/htmlcanvas.go
@@ -45,18 +45,18 @@ func (r *HTMLCanvas) Size() (float64, float64) {
 
 func (r *HTMLCanvas) writePath(path *canvas.Path) {
 	r.ctx.Call("beginPath")
-	for _, seg := range path.Segments() {
-		end := seg.End
-		switch seg.Cmd {
+	for scanner := path.Scanner(); scanner.Scan(); {
+		end := scanner.End()
+		switch scanner.Cmd() {
 		case canvas.MoveToCmd:
 			r.ctx.Call("moveTo", end.X*r.dpm, r.height-end.Y*r.dpm)
 		case canvas.LineToCmd:
 			r.ctx.Call("lineTo", end.X*r.dpm, r.height-end.Y*r.dpm)
 		case canvas.QuadToCmd:
-			cp := seg.CP1()
+			cp := scanner.CP1()
 			r.ctx.Call("quadraticCurveTo", cp.X*r.dpm, r.height-cp.Y*r.dpm, end.X*r.dpm, r.height-end.Y*r.dpm)
 		case canvas.CubeToCmd:
-			cp1, cp2 := seg.CP1(), seg.CP2()
+			cp1, cp2 := scanner.CP1(), scanner.CP2()
 			r.ctx.Call("bezierCurveTo", cp1.X*r.dpm, r.height-cp1.Y*r.dpm, cp2.X*r.dpm, r.height-cp2.Y*r.dpm, end.X*r.dpm, r.height-end.Y*r.dpm)
 		case canvas.ArcToCmd:
 			panic("arcs should have been replaced")

--- a/renderers/tex/tex.go
+++ b/renderers/tex/tex.go
@@ -63,21 +63,21 @@ func (r *TeX) getColor(col color.RGBA) string {
 
 func (r *TeX) writePath(path *canvas.Path) {
 	path = path.ReplaceArcs() // sometimes arcs generate errors of the form: Dimension too large
-	for _, seg := range path.Segments() {
-		end := seg.End
-		switch seg.Cmd {
+	for scanner := path.Scanner(); scanner.Scan(); {
+		end := scanner.End()
+		switch scanner.Cmd() {
 		case canvas.MoveToCmd:
 			fmt.Fprintf(r.w, "\n\\pgfpathmoveto{\\pgfpoint{%vmm}{%vmm}}", dec(end.X), dec(end.Y))
 		case canvas.LineToCmd:
 			fmt.Fprintf(r.w, "\n\\pgfpathlineto{\\pgfpoint{%vmm}{%vmm}}", dec(end.X), dec(end.Y))
 		case canvas.QuadToCmd:
-			cp := seg.CP1()
+			cp := scanner.CP1()
 			fmt.Fprintf(r.w, "\n\\pgfpathquadraticcurveto{\\pgfpoint{%vmm}{%vmm}}{\\pgfpoint{%vmm}{%vmm}}", dec(cp.X), dec(cp.Y), dec(end.X), dec(end.Y))
 		case canvas.CubeToCmd:
-			cp1, cp2 := seg.CP1(), seg.CP2()
+			cp1, cp2 := scanner.CP1(), scanner.CP2()
 			fmt.Fprintf(r.w, "\n\\pgfpathcurveto{\\pgfpoint{%vmm}{%vmm}}{\\pgfpoint{%vmm}{%vmm}}{\\pgfpoint{%vmm}{%vmm}}", dec(cp1.X), dec(cp1.Y), dec(cp2.X), dec(cp2.Y), dec(end.X), dec(end.Y))
 		case canvas.ArcToCmd:
-			rx, ry, rot, large, sweep := seg.Arc()
+			rx, ry, rot, large, sweep := scanner.Arc()
 			iLarge := 0
 			if large {
 				iLarge = 1


### PR DESCRIPTION
Commit 43d3c75bf9675b3ce65e0ca650ed154818df2e52 added a new path scanner which functionally replaced the older 'Segments' method. (As suggested in Issue #181)
This PR replaces the uses of Segments in the renderers of gio, htmlcanvas and tex with the new scanner.
I tested the examples of all three and they still function just like before.
