### PR TITLE
fix stroke width scaling being NaN with CartesianIV

### DIFF
--- a/renderers/htmlcanvas/htmlcanvas.go
+++ b/renderers/htmlcanvas/htmlcanvas.go
@@ -74,7 +74,7 @@ func (r *HTMLCanvas) RenderPath(path *canvas.Path, style canvas.Style, m canvas.
 
 	strokeUnsupported := false
 	if m.IsSimilarity() {
-		scale := math.Sqrt(m.Det())
+		scale := math.Sqrt(math.Abs(m.Det()))
 		style.StrokeWidth *= scale
 		style.DashOffset *= scale
 		dashes := make([]float64, len(style.Dashes))

--- a/renderers/pdf/pdf.go
+++ b/renderers/pdf/pdf.go
@@ -93,7 +93,7 @@ func (r *PDF) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 	}
 	if !strokeUnsupported {
 		if m.IsSimilarity() {
-			scale := math.Sqrt(m.Det())
+			scale := math.Sqrt(math.Abs(m.Det()))
 			style.StrokeWidth *= scale
 			style.DashOffset *= scale
 			dashes := make([]float64, len(style.Dashes))

--- a/renderers/ps/ps.go
+++ b/renderers/ps/ps.go
@@ -182,7 +182,7 @@ func (r *PS) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix) 
 	}
 	if !strokeUnsupported {
 		if m.IsSimilarity() {
-			scale := math.Sqrt(m.Det())
+			scale := math.Sqrt(math.Abs(m.Det()))
 			style.StrokeWidth *= scale
 			style.DashOffset *= scale
 			dashes := make([]float64, len(style.Dashes))

--- a/renderers/svg/svg.go
+++ b/renderers/svg/svg.go
@@ -170,7 +170,7 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 	}
 	if !strokeUnsupported {
 		if m.IsSimilarity() {
-			scale := math.Sqrt(m.Det())
+			scale := math.Sqrt(math.Abs(m.Det()))
 			style.StrokeWidth *= scale
 			style.DashOffset *= scale
 			dashes := make([]float64, len(style.Dashes))

--- a/renderers/tex/tex.go
+++ b/renderers/tex/tex.go
@@ -188,7 +188,7 @@ func (r *TeX) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 
 	strokeUnsupported := false
 	if m.IsSimilarity() {
-		scale := math.Sqrt(m.Det())
+		scale := math.Sqrt(math.Abs(m.Det()))
 		style.StrokeWidth *= scale
 		style.DashOffset *= scale
 		dashes := make([]float64, len(style.Dashes))


### PR DESCRIPTION
When using `CartesianIV` as your coordinate system, you end up with a translation matrix that looks like
```
[[1 0]
 [0 -1]]
```
which has a negative determinant. This PR takes the absolute value of the determinant before calculating the square root to avoid the scaling of the stroke width becoming `NaN`.