### PR TITLE
Gradient support

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -108,11 +108,18 @@ type Style struct {
 	DashOffset   float64
 	Dashes       []float64
 	FillRule     // TODO: test for all renderers
+
+	// Gradient support
+	GradientInfo *Gradient
 }
 
 // HasFill returns true if the style has a fill
 func (style Style) HasFill() bool {
 	return style.FillColor.A != 0
+}
+
+func (style Style) HasGradient() bool {
+	return style.GradientInfo != nil
 }
 
 // HasStroke returns true if the style has a stroke

--- a/examples/gradient/.gitignore
+++ b/examples/gradient/.gitignore
@@ -1,0 +1,2 @@
+gradient
+out.png

--- a/examples/gradient/.gitignore
+++ b/examples/gradient/.gitignore
@@ -1,2 +1,2 @@
-gradient
+gradient*
 out.png

--- a/examples/gradient/Makefile
+++ b/examples/gradient/Makefile
@@ -1,0 +1,3 @@
+all:
+	go build .
+	./gradient

--- a/examples/gradient/main.go
+++ b/examples/gradient/main.go
@@ -31,10 +31,13 @@ func main() {
 		panic(err)
 	}
 
-	face := fontDejaVu.Face(100.0, canvas.Black, canvas.FontRegular, canvas.FontNormal)
+	f := canvas.NewLinearGradient(0, 0, 100, 100)
+	f.AddColorStop(0, canvas.Antiquewhite)
+	f.AddColorStop(1, canvas.Greenyellow)
 
-	ctx.SetFillColor(canvas.Mediumaquamarine)
-	ctx.Style.GradientInfo = &g
+	face := fontDejaVu.Face(100.0, canvas.Black, canvas.FontRegular, canvas.FontNormal)
+	face.GradientInfo = &f
+
 	ctx.DrawText(10, 10, canvas.NewTextLine(face, "Lorem ipsum", canvas.Left))
 
 	// Rasterize the canvas and write to a PNG file with 3.2 dots-per-mm (320x320 px)

--- a/examples/gradient/main.go
+++ b/examples/gradient/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/canvas/renderers"
+)
+
+func main() {
+	// Create new canvas of dimension 100x100 mm
+	c := canvas.New(1000, 1000)
+
+	// Create a canvas context used to keep drawing state
+	ctx := canvas.NewContext(c)
+
+	// Create a triangle path from an SVG path and draw it to the canvas
+	triangle, err := canvas.ParseSVG("L600 00L300 600z")
+	if err != nil {
+		panic(err)
+	}
+
+	g := canvas.NewRadialGradient(500, 500, 100, 200, 500, 500)
+	g.AddColorStop(0, canvas.Mediumaquamarine)
+	g.AddColorStop(1, canvas.Red)
+
+	ctx.Style.GradientInfo = &g
+	ctx.DrawPath(200, 200, triangle)
+	ctx.Style.GradientInfo = nil
+
+	fontDejaVu := canvas.NewFontFamily("dejavu")
+	if err := fontDejaVu.LoadFontFile("../../resources/DejaVuSerif.ttf", canvas.FontRegular); err != nil {
+		panic(err)
+	}
+
+	face := fontDejaVu.Face(100.0, canvas.Black, canvas.FontRegular, canvas.FontNormal)
+
+	ctx.SetFillColor(canvas.Mediumaquamarine)
+	ctx.Style.GradientInfo = &g
+	ctx.DrawText(10, 10, canvas.NewTextLine(face, "Lorem ipsum", canvas.Left))
+
+	// Rasterize the canvas and write to a PNG file with 3.2 dots-per-mm (320x320 px)
+	renderers.Write("out.png", c)
+}

--- a/examples/gradient/main.go
+++ b/examples/gradient/main.go
@@ -6,11 +6,12 @@ import (
 )
 
 func main() {
-	// Create new canvas of dimension 100x100 mm
 	c := canvas.New(1000, 1000)
-
-	// Create a canvas context used to keep drawing state
 	ctx := canvas.NewContext(c)
+
+	ctx.SetFillColor(canvas.White)
+	ctx.DrawPath(0, 0, canvas.Rectangle(ctx.Width(), ctx.Height()))
+	ctx.Fill()
 
 	// Create a triangle path from an SVG path and draw it to the canvas
 	triangle, err := canvas.ParseSVG("L600 00L300 600z")
@@ -31,15 +32,14 @@ func main() {
 		panic(err)
 	}
 
-	f := canvas.NewLinearGradient(0, 0, 100, 100)
-	f.AddColorStop(0, canvas.Antiquewhite)
-	f.AddColorStop(1, canvas.Greenyellow)
+	f := canvas.NewLinearGradient(0, 0, 300, 200)
+	f.AddColorStop(0, canvas.Red)
+	f.AddColorStop(1, canvas.Blue)
 
-	face := fontDejaVu.Face(100.0, canvas.Black, canvas.FontRegular, canvas.FontNormal)
+	face := fontDejaVu.Face(300.0, canvas.Black, canvas.FontRegular, canvas.FontNormal)
 	face.GradientInfo = &f
 
-	ctx.DrawText(10, 10, canvas.NewTextLine(face, "Lorem ipsum", canvas.Left))
+	ctx.DrawText(10, 30, canvas.NewTextLine(face, "Lorem ipsum", canvas.Left))
 
-	// Rasterize the canvas and write to a PNG file with 3.2 dots-per-mm (320x320 px)
 	renderers.Write("out.png", c)
 }

--- a/font.go
+++ b/font.go
@@ -437,8 +437,9 @@ type FontFace struct {
 	Style   FontStyle
 	Variant FontVariant
 
-	Color color.RGBA
-	Deco  []FontDecorator
+	GradientInfo *Gradient
+	Color        color.RGBA
+	Deco         []FontDecorator
 
 	// faux styles for bold, italic, and sub- and superscript
 	FauxBold, FauxItalic float64

--- a/path_gradient.go
+++ b/path_gradient.go
@@ -1,0 +1,246 @@
+package canvas
+
+import (
+	"image"
+	"image/color"
+	"math"
+	"sort"
+)
+
+type Span struct {
+	Y, X0, X1 int
+	Alpha     uint32
+}
+
+type RepeatOp int
+
+const (
+	RepeatBoth RepeatOp = iota
+	RepeatX
+	RepeatY
+	RepeatNone
+)
+
+type Pattern interface {
+	At(x, y int) color.Color
+	ColorModel() color.Model
+	Bounds() image.Rectangle
+}
+
+type stop struct {
+	pos   float64
+	color color.Color
+}
+
+type stops []stop
+
+// Len satisfies the Sort interface.
+func (s stops) Len() int {
+	return len(s)
+}
+
+// Less satisfies the Sort interface.
+func (s stops) Less(i, j int) bool {
+	return s[i].pos < s[j].pos
+}
+
+// Swap satisfies the Sort interface.
+func (s stops) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type Gradient interface {
+	Pattern
+	AddColorStop(offset float64, color color.Color)
+}
+
+// Linear Gradient
+type linearGradient struct {
+	x0, y0, x1, y1 float64
+	stops          stops
+}
+
+func (g *linearGradient) At(x, y int) color.Color {
+	if len(g.stops) == 0 {
+		return color.Transparent
+	}
+
+	fx, fy := float64(x), float64(y)
+	x0, y0, x1, y1 := g.x0, g.y0, g.x1, g.y1
+	dx, dy := x1-x0, y1-y0
+
+	// Horizontal
+	if dy == 0 && dx != 0 {
+		return getColor((fx-x0)/dx, g.stops)
+	}
+
+	// Vertical
+	if dx == 0 && dy != 0 {
+		return getColor((fy-y0)/dy, g.stops)
+	}
+
+	// Dot product
+	s0 := dx*(fx-x0) + dy*(fy-y0)
+	if s0 < 0 {
+		return g.stops[0].color
+	}
+	// Calculate distance to (x0,y0) alone (x0,y0)->(x1,y1)
+	mag := math.Hypot(dx, dy)
+	u := ((fx-x0)*-dy + (fy-y0)*dx) / (mag * mag)
+	x2, y2 := x0+u*-dy, y0+u*dx
+	d := math.Hypot(fx-x2, fy-y2) / mag
+	return getColor(d, g.stops)
+}
+
+func (g *linearGradient) Bounds() image.Rectangle {
+	x0, y0, x1, y1 := g.x0, g.y0, g.x1, g.y1
+	return image.Rect(int(x0), int(y0), int(x1), int(y1))
+}
+
+func (g *linearGradient) ColorModel() color.Model {
+	return color.RGBAModel
+}
+
+func (g *linearGradient) AddColorStop(offset float64, color color.Color) {
+	g.stops = append(g.stops, stop{pos: offset, color: color})
+	sort.Sort(g.stops)
+}
+
+func NewLinearGradient(x0, y0, x1, y1 float64) Gradient {
+	g := &linearGradient{
+		x0: x0, y0: y0,
+		x1: x1, y1: y1,
+	}
+	return g
+}
+
+// Radial Gradient
+type circle struct {
+	x, y, r float64
+}
+
+type radialGradient struct {
+	c0, c1, cd     circle
+	x0, y0, x1, y1 float64
+	a, inva        float64
+	mindr          float64
+	stops          stops
+}
+
+func dot3(x0, y0, z0, x1, y1, z1 float64) float64 {
+	return x0*x1 + y0*y1 + z0*z1
+}
+
+func (g *radialGradient) At(x, y int) color.Color {
+	if len(g.stops) == 0 {
+		return color.Transparent
+	}
+
+	// copy from pixman's pixman-radial-gradient.c
+
+	dx, dy := float64(x)+0.5-g.c0.x, float64(y)+0.5-g.c0.y
+	b := dot3(dx, dy, g.c0.r, g.cd.x, g.cd.y, g.cd.r)
+	c := dot3(dx, dy, -g.c0.r, dx, dy, g.c0.r)
+
+	if g.a == 0 {
+		if b == 0 {
+			return color.Transparent
+		}
+		t := 0.5 * c / b
+		if t*g.cd.r >= g.mindr {
+			return getColor(t, g.stops)
+		}
+		return color.Transparent
+	}
+
+	discr := dot3(b, g.a, 0, b, -c, 0)
+	if discr >= 0 {
+		sqrtdiscr := math.Sqrt(discr)
+		t0 := (b + sqrtdiscr) * g.inva
+		t1 := (b - sqrtdiscr) * g.inva
+
+		if t0*g.cd.r >= g.mindr {
+			return getColor(t0, g.stops)
+		} else if t1*g.cd.r >= g.mindr {
+			return getColor(t1, g.stops)
+		}
+	}
+
+	return color.Transparent
+}
+
+func (g *radialGradient) AddColorStop(offset float64, color color.Color) {
+	g.stops = append(g.stops, stop{pos: offset, color: color})
+	sort.Sort(g.stops)
+}
+
+func (g *radialGradient) Bounds() image.Rectangle {
+	x0, y0, x1, y1 := g.x0, g.y0, g.x1, g.y1
+	return image.Rect(int(x0), int(y0), int(x1), int(y1))
+}
+
+func (g *radialGradient) ColorModel() color.Model {
+	return color.RGBAModel
+}
+
+func NewRadialGradient(x0, y0, r0, x1, y1, r1 float64) Gradient {
+	c0 := circle{x0, y0, r0}
+	c1 := circle{x1, y1, r1}
+	cd := circle{x1 - x0, y1 - y0, r1 - r0}
+	a := dot3(cd.x, cd.y, -cd.r, cd.x, cd.y, cd.r)
+	var inva float64
+	if a != 0 {
+		inva = 1.0 / a
+	}
+	mindr := -c0.r
+	g := &radialGradient{
+		c0:    c0,
+		c1:    c1,
+		cd:    cd,
+		a:     a,
+		inva:  inva,
+		mindr: mindr,
+		x0:    x0,
+		x1:    x1,
+		y0:    y0,
+		y1:    y1,
+	}
+	return g
+}
+
+func getColor(pos float64, stops stops) color.Color {
+	if pos <= 0.0 || len(stops) == 1 {
+		return stops[0].color
+	}
+
+	last := stops[len(stops)-1]
+
+	if pos >= last.pos {
+		return last.color
+	}
+
+	for i, stop := range stops[1:] {
+		if pos < stop.pos {
+			pos = (pos - stops[i].pos) / (stop.pos - stops[i].pos)
+			return colorLerp(stops[i].color, stop.color, pos)
+		}
+	}
+
+	return last.color
+}
+
+func colorLerp(c0, c1 color.Color, t float64) color.Color {
+	r0, g0, b0, a0 := c0.RGBA()
+	r1, g1, b1, a1 := c1.RGBA()
+
+	return color.RGBA{
+		lerp(r0, r1, t),
+		lerp(g0, g1, t),
+		lerp(b0, b1, t),
+		lerp(a0, a1, t),
+	}
+}
+
+func lerp(a, b uint32, t float64) uint8 {
+	return uint8(int32(float64(a)*(1.0-t)+float64(b)*t) >> 8)
+}

--- a/path_gradient.go
+++ b/path_gradient.go
@@ -95,6 +95,7 @@ func (g *linearGradient) At(x, y int) color.Color {
 func (g *linearGradient) Bounds() image.Rectangle {
 	x0, y0, x1, y1 := g.x0, g.y0, g.x1, g.y1
 	return image.Rect(int(x0), int(y0), int(x1), int(y1))
+	// return image.Rect(-1e6, -1e6, 1e6, 1e6)
 }
 
 func (g *linearGradient) ColorModel() color.Model {

--- a/renderers/rasterizer/rasterizer.go
+++ b/renderers/rasterizer/rasterizer.go
@@ -107,7 +107,12 @@ func (r *Rasterizer) RenderPath(path *canvas.Path, style canvas.Style, m canvas.
 		return // has no size
 	}
 
-	if style.HasFill() {
+	if style.HasGradient() {
+		ras := vector.NewRasterizer(w, h)
+		fill = fill.Translate(-float64(x)/dpmm, -float64(y)/dpmm)
+		fill.ToRasterizer(ras, r.resolution)
+		ras.Draw(r.Image, image.Rect(x, size.Y-y, x+w, size.Y-y-h), *style.GradientInfo, image.Point{dx, dy})
+	} else if style.HasFill() {
 		ras := vector.NewRasterizer(w, h)
 		fill = fill.Translate(-float64(x)/dpmm, -float64(y)/dpmm)
 		fill.ToRasterizer(ras, r.resolution)

--- a/text.go
+++ b/text.go
@@ -1135,6 +1135,7 @@ func (t *Text) RenderAsPath(r Renderer, m Matrix, resolution Resolution) {
 			if span.IsText() {
 				style := DefaultStyle
 				style.FillColor = span.Face.Color
+				style.GradientInfo = span.Face.GradientInfo
 				p, _, err := span.Face.toPath(span.Glyphs, span.Face.PPEM(resolution))
 				if err != nil {
 					panic(err)


### PR DESCRIPTION
We use the Gradient implementation in our application that supports paths and the text itself. It provides linear and radial gradients with multi-color stops. It adapts well to the existing font decoration code too.

![image](https://user-images.githubusercontent.com/9026786/225879214-2fa9a04b-7152-4f04-8750-a1c546b3c375.png)

Note: We've only implemented the gradient support for the rasterizer itself. This feature might also need to be better structured, but we tried to make it API backward-compatible.

There is also an example app that renders the gradient preview from above. Feel free to tweak, adapt or modify the code as you see fit, and let us know if we should improve anything.