### PR TITLE
Fix Coordinate Conversion in Text Boxes on Canvas Rotation

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -674,7 +674,7 @@ func (c *Context) DrawText(x, y float64, text *Text) {
 	if c.coordSystem == CartesianII || c.coordSystem == CartesianIII {
 		m = m.ReflectX()
 	}
-	m = m.Mul(c.view)
+	m = c.view.Translate(coord.X, coord.Y)
 	if c.coordSystem == CartesianIII || c.coordSystem == CartesianIV {
 		m = m.ReflectY()
 	}


### PR DESCRIPTION
Description:
This PR addresses a bug where the coordinate conversion in the text boxes is not performed correctly when the canvas is rotated 90 degrees. Proper coordinate conversion is crucial for accurate positioning and rendering of text boxes on the canvas, and this bug was causing misplacement and distortion of text boxes upon rotation.
