### PR TITLE
Add functions for Persian/Arabic number check and string reversal

### DIFF
--- a/text/harfbuzz.go
+++ b/text/harfbuzz.go
@@ -42,8 +42,33 @@ func NewShaperSFNT(sfnt *font.SFNT) (Shaper, error) {
 func (s Shaper) Destroy() {
 }
 
+// Check if a rune is a Persian or Arabic number
+func isPersianOrArabicNumber(r rune) bool {
+	return (r >= '\u06F0' && r <= '\u06F9') || (r >= '\u0660' && r <= '\u0669')
+}
+
+// Function to reverse a string
+func reverse(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}
+
+// Function to check if a string contains Persian numbers and reverse it
+func reverseIfContainsPersianOrArabicNumbers(s string) string {
+	for _, r := range s {
+		if isPersianOrArabicNumber(r) {
+			return reverse(s)
+		}
+	}
+	return s
+}
+
 // Shape shapes the string for a given direction, script, and language.
 func (s Shaper) Shape(text string, ppem uint16, direction Direction, script Script, lang string, features string, variations string) ([]Glyph, Direction) {
+	text = reverseIfContainsPersianOrArabicNumbers(text)
 	buf := harfbuzz.NewBuffer()
 	rtext := []rune(text)
 	buf.AddRunes(rtext, 0, -1)


### PR DESCRIPTION
### Summary
This PR aims to fix the bug outlined in issue #244 where numbers in right-to-left (RTL) languages (such as Persian, Arabic) are being inserted from right to left instead of from left to right.

### Changes
Added a function isPersianOrArabicNumber(r rune) bool to check if a rune is a Persian or Arabic number.
Added a utility function reverse(s string) to reverse a string.
Added a function reverseIfContainsPersianOrArabicNumbers(s string) string that reverses the string only if it contains Persian or Arabic numbers.