### PR TITLE
Example program that lists all discovered fonts

### DIFF
--- a/examples/font-list/main.go
+++ b/examples/font-list/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"github.com/tdewolff/canvas/font"
+	"log"
+	"sort"
+	"strings"
+)
+
+func StyleString(style font.Style) string {
+	switch style {
+	case font.UnknownStyle:
+		return "Unknown"
+	case font.Regular:
+		return "Regular"
+	case font.Thin:
+		return "Thin"
+	case font.ExtraLight:
+		return "ExtraLight"
+	case font.Light:
+		return "Light"
+	case font.Medium:
+		return "Medium"
+	case font.SemiBold:
+		return "SemiBold"
+	case font.Bold:
+		return "Bold"
+	case font.ExtraBold:
+		return "ExtraBold"
+	case font.Black:
+		return "Black"
+	case font.Italic:
+		return "Italic"
+	}
+	return ""
+}
+
+// Finds and lists the default system fonts
+func main() {
+	var fonts *font.SystemFonts
+	dirs := font.DefaultFontDirs()
+	fonts, err := font.FindSystemFonts(dirs)
+	if err != nil {
+		log.Fatalf("Could not find system fonts: %v", err)
+	}
+	// list default system fonts
+	fmt.Println("Default Fonts by Category:\n")
+	for category, items := range fonts.Defaults {
+		fmt.Println(category)
+		for _, item := range items {
+			fmt.Println("  ", item)
+		}
+	}
+	// list all fonts
+	var resultStrings []string
+	for category, styleMap := range fonts.Fonts {
+		var styles []font.Style
+		for _, metadata := range styleMap {
+			styles = append(styles, metadata.Style)
+		}
+		sort.SliceStable(styles, func(i, j int) bool {
+			return styles[i] < styles[j]
+		})
+		var styleNames []string
+		for _, style := range styles {
+			styleNames = append(styleNames, StyleString(style))
+		}
+		fontStr := fmt.Sprintf("%s: [%s]", category, strings.Join(styleNames, ", "))
+		resultStrings = append(resultStrings, fontStr)
+	}
+	sort.Strings(resultStrings)
+	fmt.Println("\n\nAll Fonts\nFont Family: [Available Styles]\n")
+	for _, fontStr := range resultStrings {
+		fmt.Println(fontStr)
+	}
+}


### PR DESCRIPTION
Addresses issue: https://github.com/tdewolff/canvas/issues/254

This is just a simple example that uses Canvas's `font.FindSystemFonts` along `font.DefaultFontDirs()` to print all discovered fonts along with their category (for default fonts) and available styles for all fonts. Below is the abridged output on my system (Linux - KDE Neon).
```
Default Fonts by Category:

cursive
   ITC Zapf Chancery Std
   Zapfino
   Comic Sans MS
system-ui
   Cantarell
   Noto Sans UI
   Segoe UI
   Segoe UI Historic
   Segoe UI Symbol
serif
   Noto Serif
   DejaVu Serif
   Times New Roman
   Thorndale AMT
   Luxi Serif
   Nimbus Roman No9 L
   Nimbus Roman
   Times
sans-serif
   Noto Sans
   DejaVu Sans
   Verdana
   Arial
   Albany AMT
   Luxi Sans
   Nimbus Sans L
   Nimbus Sans
   Helvetica
   Lucida Sans Unicode
   BPG Glaho International
   Tahoma
monospace
   Noto Sans Mono
   DejaVu Sans Mono
   Inconsolata
   Andale Mono
   Courier New
   Cumberland AMT
   Luxi Mono
   Nimbus Mono L
   Nimbus Mono
   Nimbus Mono PS
   Courier
fantasy
   Impact
   Copperplate Gothic Std
   Cooper Std
   Bauhaus Std


All Fonts
Font Family: [Available Styles]

C059: [Regular, Bold]
D050000L: [Regular]
DejaVu Math TeX Gyre: [Regular]
DejaVu Sans Mono: [Regular, Light, Bold]
DejaVu Sans: [Regular, ExtraLight, Light, Bold]
DejaVu Serif: [Regular, Light, Bold]
Droid Sans Fallback: [Regular]
Gentium Basic: [Regular, Bold]
Gentium Book Basic: [Regular, Bold]
Gentium: [Regular]
GentiumAlt: [Regular]
Hack: [Regular, Bold]
Lato: [Regular, Thin, Light, Medium, Bold, Black]
Liberation Mono: [Regular, Bold]
Liberation Sans Narrow: [Regular, Bold]
Liberation Sans: [Regular, Bold]
Liberation Serif: [Regular, Bold]
Nimbus Mono PS: [Regular, Bold]
Nimbus Roman: [Regular, Bold]
Nimbus Sans Narrow: [Regular, Bold]
Nimbus Sans: [Regular, Bold]
Noto Color Emoji: [Regular]
Noto Kufi Arabic: [Regular, Bold]
Noto Looped Lao UI: [Regular, Bold]
Noto Looped Lao: [Regular, Bold]
Noto Looped Thai UI: [Regular, Bold]
Noto Looped Thai: [Regular, Bold]
Noto Mono: [Regular]
Noto Music: [Regular]
Noto Naskh Arabic UI: [Regular, Bold]
Noto Naskh Arabic: [Regular, Bold]
Noto Nastaliq Urdu: [Regular, Bold]
Noto Rashi Hebrew: [Regular, Bold]
Noto Sans Adlam Unjoined: [Regular, Bold]
Noto Sans Adlam: [Regular, Bold]
...
many more 
...
PowerlineSymbols: [Medium]
Standard Symbols PS: [Regular]
URW Bookman: [Light]
URW Gothic: [Light]
Ubuntu Condensed: [Regular]
Ubuntu Mono: [Regular, Bold]
Ubuntu: [Regular, Thin, Light, Medium, Bold]
Z003: [Medium]

```

I'm not sure this is great as an example compared to what is already in the `examples/` folder, but thought I would share it as it was useful in debugging issue #254 