### PR TITLE
Use fill-opacity and stroke-opacity in the SVG renderer

### DIFF
--- a/renderers/svg/svg.go
+++ b/renderers/svg/svg.go
@@ -195,6 +195,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 			if !style.Fill.IsColor() || style.Fill.Color != canvas.Black {
 				fmt.Fprintf(r.w, `" fill="`)
 				r.writePaint(r.w, style.Fill)
+				if style.Fill.IsColor() && style.Fill.Color.A != 255 {
+					fmt.Fprintf(r.w, `" fill-opacity="%v`, dec(float64(style.Fill.Color.A)/255.0))
+				}
 			}
 			if style.FillRule == canvas.EvenOdd {
 				fmt.Fprintf(r.w, `" fill-rule="evenodd`)
@@ -208,6 +211,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 			if !style.Fill.IsColor() || style.Fill.Color != canvas.Black {
 				fmt.Fprintf(b, ";fill:")
 				r.writePaint(b, style.Fill)
+				if style.Fill.IsColor() && style.Fill.Color.A != 255 {
+					fmt.Fprintf(b, ";fill-opacity:%v", dec(float64(style.Fill.Color.A)/255.0))
+				}
 			}
 			if style.FillRule == canvas.EvenOdd {
 				fmt.Fprintf(b, ";fill-rule:evenodd")
@@ -218,6 +224,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 		if style.HasStroke() && !strokeUnsupported {
 			fmt.Fprintf(b, `;stroke:`)
 			r.writePaint(b, style.Stroke)
+			if style.Stroke.IsColor() && style.Stroke.Color.A != 255 {
+				fmt.Fprintf(b, ";stroke-opacity:%v", dec(float64(style.Stroke.Color.A)/255.0))
+			}
 			if style.StrokeWidth != 1.0 {
 				fmt.Fprintf(b, ";stroke-width:%v", dec(style.StrokeWidth))
 			}
@@ -274,6 +283,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 		if !style.Stroke.IsColor() || style.Stroke.Color != canvas.Black {
 			fmt.Fprintf(r.w, `" fill="`)
 			r.writePaint(r.w, style.Stroke)
+			if style.Stroke.IsColor() && style.Stroke.Color.A != 255 {
+				fmt.Fprintf(r.w, `" fill-opacity="%v`, dec(float64(style.Stroke.Color.A)/255.0))
+			}
 		}
 		if style.FillRule == canvas.EvenOdd {
 			fmt.Fprintf(r.w, `" fill-rule="evenodd`)
@@ -326,6 +338,9 @@ func (r *SVG) writeFontStyle(face, faceMain *canvas.FontFace, rtl bool) {
 		if !face.Fill.Equal(faceMain.Fill) {
 			fmt.Fprintf(r.w, `;fill:`)
 			r.writePaint(r.w, face.Fill)
+			if face.Fill.IsColor() && face.Fill.Color.A != 255 {
+				fmt.Fprintf(r.w, `;fill-opacity:%v`, dec(float64(face.Fill.Color.A)/255.0))
+			}
 		}
 		if rtl {
 			fmt.Fprintf(r.w, `;direction:rtl`)
@@ -333,6 +348,9 @@ func (r *SVG) writeFontStyle(face, faceMain *canvas.FontFace, rtl bool) {
 	} else if differences == 1 && !face.Fill.Equal(faceMain.Fill) {
 		fmt.Fprintf(r.w, `" fill="`)
 		r.writePaint(r.w, face.Fill)
+		if face.Fill.IsColor() && face.Fill.Color.A != 255 {
+			fmt.Fprintf(r.w, `" fill-opacity="%v`, dec(float64(face.Fill.Color.A)/255.0))
+		}
 	} else if 0 < differences {
 		fmt.Fprintf(r.w, `" style="`)
 		buf := &bytes.Buffer{}
@@ -350,6 +368,9 @@ func (r *SVG) writeFontStyle(face, faceMain *canvas.FontFace, rtl bool) {
 		if !face.Fill.Equal(faceMain.Fill) {
 			fmt.Fprintf(buf, `;fill:`)
 			r.writePaint(r.w, face.Fill)
+			if face.Fill.IsColor() && face.Fill.Color.A != 255 {
+				fmt.Fprintf(buf, `;fill-opacity:%v`, dec(float64(face.Fill.Color.A)/255.0))
+			}
 		}
 		if rtl {
 			fmt.Fprintf(r.w, `;direction:rtl`)
@@ -402,6 +423,9 @@ func (r *SVG) RenderText(text *canvas.Text, m canvas.Matrix) {
 	if !faceMain.Fill.IsColor() || faceMain.Fill.Color != canvas.Black {
 		fmt.Fprintf(r.w, `;fill:`)
 		r.writePaint(r.w, faceMain.Fill)
+		if faceMain.Fill.IsColor() && faceMain.Fill.Color.A != 255 {
+			fmt.Fprintf(r.w, `;fill-opacity:%v`, dec(float64(faceMain.Fill.Color.A)/255.0))
+		}
 	}
 	if text.WritingMode != canvas.HorizontalTB {
 		if text.WritingMode == canvas.VerticalLR {
@@ -580,6 +604,8 @@ func (r *SVG) writePaint(w io.Writer, paint canvas.Paint) {
 	} else if paint.IsGradient() {
 		fmt.Fprintf(w, "url(#%v)", r.getPattern(paint.Gradient))
 	} else {
-		fmt.Fprintf(w, "%v", canvas.CSSColor(paint.Color))
+		c := paint.Color
+		c.A = 255
+		fmt.Fprintf(w, "%v", canvas.CSSColor(c))
 	}
 }


### PR DESCRIPTION
The Svg 1.1 specification does not allow the use of rgba values for `fill` and `stroke`, but the Canvas SVG renderer uses them.

As a result, some SVG viewers will not be able to correctly display the SVG files output by Canvas.

To solve this, instead of specifying rgba values for `fill` and `stroke`, set opacity separately to `fill-opacity` and `stroke-opacity`.

### Reference
- https://www.w3.org/TR/SVG11/types.html#DataTypeColor
- https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Fills_and_Strokes