### PR TITLE
fix: windows system font path

### DIFF
--- a/font/system.go
+++ b/font/system.go
@@ -70,7 +70,7 @@ func DefaultFontDirs() []string {
 			sysRoot = "C:"
 		}
 		dirs = []string{
-			filepath.Join(filepath.VolumeName(sysRoot), `Windows`, "Fonts"),
+			filepath.Join(filepath.VolumeName(sysRoot), `\Windows`, "Fonts"),
 		}
 	}
 	return dirs


### PR DESCRIPTION
I failed to load system fonts on Windows, because `filepath.Join("C:", "Windows", "Fonts")` result in `"C:Windows\Fonts"`.

See [https://github.com/golang/go/blob/go1.21.6/src/path/filepath/path_windows.go#L262](https://github.com/golang/go/blob/go1.21.6/src/path/filepath/path_windows.go#L262)