### PR TITLE
fix: fix slice init length

### DIFF
--- a/renderers/gonumplot.go
+++ b/renderers/gonumplot.go
@@ -51,7 +51,7 @@ func (r *GonumPlot) SetLineWidth(length vg.Length) {
 //
 // The initial dash pattern is a solid line.
 func (r *GonumPlot) SetLineDash(pattern []vg.Length, offset vg.Length) {
-	array := make([]float64, len(pattern))
+	array := make([]float64, 0, len(pattern))
 	for _, dash := range pattern {
 		array = append(array, float64(dash*mmPerPt))
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of  `len(pattern)`   rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW