### PR TITLE
fix(ioutil): transition deprecated methods

### DIFF
--- a/canvas_test.go
+++ b/canvas_test.go
@@ -55,13 +55,13 @@ func TestCanvas(t *testing.T) {
 	//buf.Reset()
 	//pdfCompress = false
 	//c.WritePDF(buf)
-	//ioutil.WriteFile("test/canvas.pdf", buf.Bytes(), 0644)
+	//os.WriteFile("test/canvas.pdf", buf.Bytes(), 0644)
 	//s = regexp.MustCompile(`stream\nx(.|\n)+\nendstream\n`).ReplaceAllString(buf.String(), "stream\n\nendstream\n") // remove embedded font
 	//test.String(t, s, "%PDF-1.7\n1 0 obj\n<< /Subtype /TrueType /Filter /FlateDecode /Length 215980 >> stream\n\nendstream\nendobj\n5 0 obj\n<< /Type /Page /Contents 4 0 R /Group << /Type /Group /CS /DeviceRGB /I true /S /Transparency >> /MediaBox [0 0 60 93] /Parent 5 0 R /Resources << /Font << /F0 2 0 R >> /XObject << /Im0 3 0 R >> >> >>\nendobj\n6 0 obj\n<< /Type /Pages /Count 1 /Kids [5 0 R] >>\nendobj\n7 0 obj\n<< /Type /Catalog /Pages 6 0 R >>\nendobj\nxref\n0 8\n0000000000 65535 f\n0000000009 00000 n\n0000216083 00000 n\n0000227285 00000 n\n0000227491 00000 n\n0000227888 00000 n\n0000228104 00000 n\n0000228161 00000 n\ntrailer\n<< /Root 7 0 R /Size 7 >>\nstarxref\n228210\n%%EOF")
 
 	//buf.Reset()
 	//c.WriteEPS(buf)
-	//ioutil.WriteFile("test/canvas.eps", buf.Bytes(), 0644)
+	//os.WriteFile("test/canvas.eps", buf.Bytes(), 0644)
 	// TODO: test EPS when fully supported
 }
 

--- a/cmd/pdftext/reader.go
+++ b/cmd/pdftext/reader.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/tdewolff/parse/v2/strconv"
 )
@@ -31,7 +30,7 @@ type pdfReader struct {
 }
 
 func NewPDFReader(reader io.Reader, password string) (*pdfReader, error) {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	} else if len(data) < 8 || !bytes.Equal(data[:7], []byte("%PDF-1.")) || data[7] < '0' || '7' < data[7] {

--- a/examples/go-chart/main.go
+++ b/examples/go-chart/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -15,7 +14,7 @@ import (
 func main() {
 	xv, yv := xvalues(), yvalues()
 
-	dejavu, err := ioutil.ReadFile("../../resources/DejaVuSerif.ttf")
+	dejavu, err := os.ReadFile("../../resources/DejaVuSerif.ttf")
 	if err != nil {
 		panic(err)
 	}

--- a/font.go
+++ b/font.go
@@ -3,7 +3,6 @@ package canvas
 import (
 	"fmt"
 	"image/color"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -253,7 +252,7 @@ func LoadSystemFont(name string, style FontStyle) (*Font, error) {
 
 // LoadFontFile loads a font from a file.
 func LoadFontFile(filename string, style FontStyle) (*Font, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font file '%s': %w", filename, err)
 	}
@@ -262,7 +261,7 @@ func LoadFontFile(filename string, style FontStyle) (*Font, error) {
 
 // LoadFontCollection loads a font from a collection file and uses the font at the specified index.
 func LoadFontCollection(filename string, index int, style FontStyle) (*Font, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load font file '%s': %w", filename, err)
 	}

--- a/preview.go
+++ b/preview.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"image/color"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,7 +16,7 @@ func loadFont(name string, style FontStyle) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to find font '%s'", name)
 	}
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 // DrawPreview draws the canvas's preview to a Context.
@@ -40,7 +39,7 @@ func DrawPreview(ctx *Context) error {
 	if err != nil {
 		return err
 	}
-	lenna, err := ioutil.ReadFile(filepath.Join(root, "resources/lenna.png"))
+	lenna, err := os.ReadFile(filepath.Join(root, "resources/lenna.png"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In Go 1.16 the ioutil methods were deprecated in favor of their os/io counterpart. This PR makes the transition to the new methods to remove the warnings.

Specifically:

- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.WriteFile` => `os.WriteFile`
- `ioutil.ReadAll` => `io.ReadAll`

All the signatures are strictly similar, so this is a drop-in change.