### PR TITLE
Make FontFace's Glyphs Method Public

### DIFF
--- a/cmd/pdftext/util.go
+++ b/cmd/pdftext/util.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"github.com/tdewolff/minify/v2"
 )
 

--- a/examples/amsterdam-centre/main.go
+++ b/examples/amsterdam-centre/main.go
@@ -11,8 +11,8 @@ import (
 	"github.com/paulmach/osm"
 	"github.com/paulmach/osm/osmapi"
 	"github.com/paulmach/osm/osmgeojson"
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 func main() {

--- a/examples/co2-mauna-loa/main.go
+++ b/examples/co2-mauna-loa/main.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var fontFamily *canvas.FontFamily

--- a/examples/fyne/main.go
+++ b/examples/fyne/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
-	"github.com/tdewolff/canvas"
-	canvasFyne "github.com/tdewolff/canvas/renderers/fyne"
+	"github.com/Seanld/canvas"
+	canvasFyne "github.com/Seanld/canvas/renderers/fyne"
 )
 
 func main() {

--- a/examples/go-chart/main.go
+++ b/examples/go-chart/main.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 	"github.com/wcharczuk/go-chart/v2"
 	"github.com/wcharczuk/go-chart/v2/drawing"
 )

--- a/examples/gonum-plot/main.go
+++ b/examples/gonum-plot/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 	"gonum.org/v1/plot"
 	"gonum.org/v1/plot/plotter"
 	"gonum.org/v1/plot/vg"

--- a/examples/html-canvas/main.go
+++ b/examples/html-canvas/main.go
@@ -7,8 +7,8 @@ package main
 import (
 	"syscall/js"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/htmlcanvas"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/htmlcanvas"
 )
 
 func main() {

--- a/examples/opengl/main.go
+++ b/examples/opengl/main.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/opengl"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/opengl"
 )
 
 func main() {

--- a/examples/tex/main.go
+++ b/examples/tex/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/tex"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/tex"
 )
 
 func main() {

--- a/examples/text-document/main.go
+++ b/examples/text-document/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/pdf"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/pdf"
 )
 
 var fontLatin *canvas.FontFamily

--- a/font.go
+++ b/font.go
@@ -693,11 +693,14 @@ func (face *FontFace) LineHeight() float64 {
 	return metrics.Ascent + metrics.Descent
 }
 
+func (face *FontFace) Glyphs(s string) []text.Glyph {
+	ppem := face.PPEM(DefaultResolution)
+	return face.Font.shaper.Shape(s, ppem, face.Direction, face.Script, face.Language, face.Font.features, face.Font.variations)
+}
+
 // TextWidth returns the width of a given string in millimeters.
 func (face *FontFace) TextWidth(s string) float64 {
-	ppem := face.PPEM(DefaultResolution)
-	glyphs := face.Font.shaper.Shape(s, ppem, face.Direction, face.Script, face.Language, face.Font.features, face.Font.variations)
-	return face.textWidth(glyphs)
+	return face.textWidth(face.Glyphs(s))
 }
 
 func (face *FontFace) textWidth(glyphs []text.Glyph) float64 {
@@ -740,8 +743,7 @@ func (face *FontFace) Decorate(width float64) *Path {
 // ToPath converts a string to its glyph paths.
 func (face *FontFace) ToPath(s string) (*Path, float64, error) {
 	ppem := face.PPEM(DefaultResolution)
-	glyphs := face.Font.shaper.Shape(s, ppem, face.Direction, face.Script, face.Language, face.Font.features, face.Font.variations)
-	return face.toPath(glyphs, ppem)
+	return face.toPath(face.Glyphs(s), ppem)
 }
 
 func (face *FontFace) toPath(glyphs []text.Glyph, ppem uint16) (*Path, float64, error) {

--- a/font.go
+++ b/font.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/tdewolff/canvas/text"
+	"github.com/Seanld/canvas/text"
 	"github.com/tdewolff/font"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tdewolff/canvas
+module github.com/Seanld/canvas
 
 go 1.22.0
 

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,8 @@ require (
 	gonum.org/v1/plot v0.15.0
 )
 
+replace github.com/tdewolff/canvas => github.com/Seanld/canvas v1.0.1
+
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	fyne.io/systray v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,6 @@ require (
 	gonum.org/v1/plot v0.15.0
 )
 
-replace github.com/tdewolff/canvas => github.com/Seanld/canvas v1.0.1
-
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	fyne.io/systray v1.11.0 // indirect

--- a/preview.go
+++ b/preview.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/tdewolff/canvas/text"
+	"github.com/Seanld/canvas/text"
 )
 
 func loadFont(name string, style FontStyle) ([]byte, error) {

--- a/renderers/fyne/fyne.go
+++ b/renderers/fyne/fyne.go
@@ -3,8 +3,8 @@ package fyne
 import (
 	"fyne.io/fyne/v2"
 	fyneCanvas "fyne.io/fyne/v2/canvas"
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/rasterizer"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/rasterizer"
 )
 
 type Fyne struct {

--- a/renderers/gochart.go
+++ b/renderers/gochart.go
@@ -5,7 +5,7 @@ import (
 	"math"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"github.com/tdewolff/font"
 	"github.com/wcharczuk/go-chart/v2"
 	"github.com/wcharczuk/go-chart/v2/drawing"

--- a/renderers/gonumplot.go
+++ b/renderers/gonumplot.go
@@ -5,7 +5,7 @@ import (
 	"image/color"
 	"math"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	canvasFont "github.com/tdewolff/font"
 	"golang.org/x/image/font"
 	gonumFont "gonum.org/v1/plot/font"

--- a/renderers/htmlcanvas/htmlcanvas.go
+++ b/renderers/htmlcanvas/htmlcanvas.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"syscall/js"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 )
 
 // HTMLCanvas is an HTMLCanvas renderer.

--- a/renderers/opengl/opengl.go
+++ b/renderers/opengl/opengl.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-gl/gl/v3.3-core/gl"
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/rasterizer"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/rasterizer"
 )
 
 // OpenGL is an open graphics library renderer.

--- a/renderers/pdf/pdf.go
+++ b/renderers/pdf/pdf.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 )
 
 type Options struct {

--- a/renderers/pdf/pdf_test.go
+++ b/renderers/pdf/pdf_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"github.com/tdewolff/test"
 )
 

--- a/renderers/pdf/util.go
+++ b/renderers/pdf/util.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"github.com/tdewolff/minify/v2"
 )
 

--- a/renderers/pdf/writer.go
+++ b/renderers/pdf/writer.go
@@ -15,8 +15,8 @@ import (
 	"time"
 	"unicode/utf16"
 
-	"github.com/tdewolff/canvas"
-	canvasText "github.com/tdewolff/canvas/text"
+	"github.com/Seanld/canvas"
+	canvasText "github.com/Seanld/canvas/text"
 	canvasFont "github.com/tdewolff/font"
 	"golang.org/x/text/encoding/charmap"
 )

--- a/renderers/ps/ps.go
+++ b/renderers/ps/ps.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"github.com/tdewolff/minify/v2"
 )
 

--- a/renderers/ps/ps_test.go
+++ b/renderers/ps/ps_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 )
 
 func TestPS(t *testing.T) {

--- a/renderers/rasterizer/rasterizer.go
+++ b/renderers/rasterizer/rasterizer.go
@@ -4,7 +4,7 @@ import (
 	"image"
 	"math"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"golang.org/x/image/draw"
 	"golang.org/x/image/math/f64"
 	"golang.org/x/image/vector"

--- a/renderers/rasterizer/util.go
+++ b/renderers/rasterizer/util.go
@@ -4,7 +4,7 @@ import (
 	"image"
 	"image/color"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"golang.org/x/image/draw"
 )
 

--- a/renderers/renderers.go
+++ b/renderers/renderers.go
@@ -10,12 +10,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/pdf"
-	"github.com/tdewolff/canvas/renderers/ps"
-	"github.com/tdewolff/canvas/renderers/rasterizer"
-	"github.com/tdewolff/canvas/renderers/svg"
-	"github.com/tdewolff/canvas/renderers/tex"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/pdf"
+	"github.com/Seanld/canvas/renderers/ps"
+	"github.com/Seanld/canvas/renderers/rasterizer"
+	"github.com/Seanld/canvas/renderers/svg"
+	"github.com/Seanld/canvas/renderers/tex"
 	"golang.org/x/image/bmp"
 	"golang.org/x/image/tiff"
 )

--- a/renderers/renderers_formats.go
+++ b/renderers/renderers_formats.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/Kagami/go-avif"
 	webp "github.com/kolesa-team/go-webp/encoder"
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers/rasterizer"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers/rasterizer"
 )
 
 func WebP(opts ...interface{}) canvas.Writer {

--- a/renderers/renderers_noformats.go
+++ b/renderers/renderers_noformats.go
@@ -5,7 +5,7 @@ package renderers
 import (
 	"fmt"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 )
 
 // WebP returns a Webp writer that uses libwebp and accepts the following options: canvas.Resolution, canvas.Colorspace, github.com/kolesa-team/go-webp/encoder.*Options

--- a/renderers/svg/svg.go
+++ b/renderers/svg/svg.go
@@ -14,8 +14,8 @@ import (
 	"math"
 	"strings"
 
-	"github.com/tdewolff/canvas"
-	canvasText "github.com/tdewolff/canvas/text"
+	"github.com/Seanld/canvas"
+	canvasText "github.com/Seanld/canvas/text"
 	"github.com/tdewolff/font"
 )
 

--- a/renderers/svg/util.go
+++ b/renderers/svg/util.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"github.com/tdewolff/minify/v2"
 )
 

--- a/renderers/tex/tex.go
+++ b/renderers/tex/tex.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 )
 
 // TeX is a TeX/PGF renderer. Be aware that TeX/PGF does not support transparency of colors.

--- a/renderers/tex/util.go
+++ b/renderers/tex/util.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"strings"
 
-	"github.com/tdewolff/canvas"
+	"github.com/Seanld/canvas"
 	"github.com/tdewolff/minify/v2"
 )
 

--- a/resources/boolean/main.go
+++ b/resources/boolean/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var font *canvas.FontFamily

--- a/resources/docs/boolean/main.go
+++ b/resources/docs/boolean/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var font *canvas.FontFamily

--- a/resources/docs/colors/main.go
+++ b/resources/docs/colors/main.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"sort"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 func hue(col color.RGBA) float64 {

--- a/resources/docs/getting-started/main.go
+++ b/resources/docs/getting-started/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 func main() {

--- a/resources/docs/hatches/main.go
+++ b/resources/docs/hatches/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var face *canvas.FontFace

--- a/resources/docs/paths/main.go
+++ b/resources/docs/paths/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var fontFamily *canvas.FontFamily

--- a/resources/docs/stroke/main.go
+++ b/resources/docs/stroke/main.go
@@ -4,8 +4,8 @@ import (
 	"image/color"
 	"math"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var fontFamily *canvas.FontFamily

--- a/resources/docs/text/main.go
+++ b/resources/docs/text/main.go
@@ -5,8 +5,8 @@ import (
 	"image/png"
 	"os"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var fontFamily, fontLatin, fontArabic, fontDevanagari, fontMongolian, fontCJK *canvas.FontFamily

--- a/resources/docs/tiling/main.go
+++ b/resources/docs/tiling/main.go
@@ -4,8 +4,8 @@ import (
 	"image/color"
 	"math"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 func main() {

--- a/resources/preview/main.go
+++ b/resources/preview/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 func main() {

--- a/resources/title/main.go
+++ b/resources/title/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"image/color"
 
-	"github.com/tdewolff/canvas"
-	"github.com/tdewolff/canvas/renderers"
+	"github.com/Seanld/canvas"
+	"github.com/Seanld/canvas/renderers"
 )
 
 var font *canvas.FontFamily

--- a/svg.go
+++ b/svg.go
@@ -810,56 +810,58 @@ func (svg *svgParser) getFontFace() *FontFace {
 	return fontFamily.Face(fontSize, svg.ctx.Style.Fill.Color)
 }
 
-func (svg *svgParser) drawShape(tag string, attrs map[string]string) {
+func (svg *svgParser) toPath(tag string, attrs map[string]string) (x float64, y float64, path *Path) {
 	switch tag {
 	case "circle":
-		cx := svg.parseDimension(attrs["cx"], svg.width)
-		cy := svg.parseDimension(attrs["cy"], svg.height)
-		r := svg.parseDimension(attrs["r"], svg.diagonal)
-		svg.ctx.DrawPath(cx, cy, Circle(r))
+		x = svg.parseDimension(attrs["cx"], svg.width)
+		y = svg.parseDimension(attrs["cy"], svg.height)
+		path = Circle(
+			svg.parseDimension(attrs["r"], svg.diagonal),
+		)
 	case "ellipse":
-		cx := svg.parseDimension(attrs["cx"], svg.width)
-		cy := svg.parseDimension(attrs["cy"], svg.height)
-		rx := svg.parseDimension(attrs["rx"], svg.width)
-		ry := svg.parseDimension(attrs["ry"], svg.height)
-		svg.ctx.DrawPath(cx, cy, Ellipse(rx, ry))
+		x = svg.parseDimension(attrs["cx"], svg.width)
+		y = svg.parseDimension(attrs["cy"], svg.height)
+		path = Ellipse(
+			svg.parseDimension(attrs["rx"], svg.width),
+			svg.parseDimension(attrs["ry"], svg.height),
+		)
 	case "path":
-		p, err := ParseSVGPath(attrs["d"])
+		var err error
+		path, err = ParseSVGPath(attrs["d"])
 		if err != nil && svg.err == nil {
 			svg.err = parse.NewErrorLexer(svg.z, "bad path: %w", err)
 		}
-		svg.ctx.DrawPath(0, 0, p)
+		x, y = 0, 0
 	case "polygon", "polyline":
+		path = &Path{}
 		points := svg.parsePoints(attrs["points"])
-		p := &Path{}
 		for i := 0; i+1 < len(points); i += 2 {
 			if i == 0 {
-				p.MoveTo(points[0], points[1])
+				path.MoveTo(points[0], points[1])
 			} else {
-				p.LineTo(points[i], points[i+1])
+				path.LineTo(points[i], points[i+1])
 			}
 		}
 		if tag == "polygon" {
-			p.Close()
+			path.Close()
 		}
-		svg.ctx.DrawPath(0.0, 0.0, p)
+		x, y = 0, 0
 	case "line":
-		p := &Path{}
+		path = &Path{}
 		x1 := svg.parseDimension(attrs["x1"], svg.width)
 		y1 := svg.parseDimension(attrs["y1"], svg.height)
 		x2 := svg.parseDimension(attrs["x2"], svg.width)
 		y2 := svg.parseDimension(attrs["y2"], svg.height)
-
-		p.MoveTo(x1, y1)
-		p.LineTo(x2, y2)
-		svg.ctx.DrawPath(0.0, 0.0, p)
+		path.MoveTo(x1, y1)
+		path.LineTo(x2, y2)
 	case "rect":
-		x := svg.parseDimension(attrs["x"], svg.width)
-		y := svg.parseDimension(attrs["y"], svg.height)
+		path = &Path{}
+		x = svg.parseDimension(attrs["x"], svg.width)
+		y = svg.parseDimension(attrs["y"], svg.height)
 		width := svg.parseDimension(attrs["width"], svg.width)
 		height := svg.parseDimension(attrs["height"], svg.height)
 		if attrs["rx"] == "" && attrs["ry"] == "" {
-			svg.ctx.DrawPath(x, y, Rectangle(width, height))
+			path = Rectangle(width, height)
 		} else {
 			// TODO: handle both rx and ry
 			var r float64
@@ -868,19 +870,41 @@ func (svg *svgParser) drawShape(tag string, attrs map[string]string) {
 			} else {
 				r = svg.parseDimension(attrs["ry"], svg.height)
 			}
-			svg.ctx.DrawPath(x, y, RoundedRectangle(width, height, r))
+			path = RoundedRectangle(width, height, r)
 		}
 	case "text":
 		svg.state.textX = svg.parseDimension(attrs["x"], svg.width)
 		svg.state.textY = svg.parseDimension(attrs["y"], svg.height)
 	}
+
+	return
+}
+
+func (svg *svgParser) drawShape(tag string, attrs map[string]string) {
+	svg.ctx.DrawPath(svg.toPath(tag, attrs))
+}
+
+type SVGPath struct {
+	Tag string
+	X, Y float64
+	*Path
 }
 
 func ParseSVG(r io.Reader) (*Canvas, error) {
+	cvs, _, err := parseSVGFull(r)
+	return cvs, err
+}
+
+func ParseSVGWithPaths(r io.Reader) (*Canvas, []SVGPath, error) {
+	return parseSVGFull(r)
+}
+
+func parseSVGFull(r io.Reader) (*Canvas, []SVGPath, error) {
 	z := parse.NewInput(r)
 	defer z.Restore()
 
 	l := xml.NewLexer(z)
+	var paths []SVGPath
 	svg := svgParser{
 		z:          z,
 		defs:       map[string]svgDef{},
@@ -892,16 +916,16 @@ func ParseSVG(r io.Reader) (*Canvas, error) {
 		switch tt {
 		case xml.ErrorToken:
 			if l.Err() != io.EOF {
-				return svg.c, l.Err()
+				return svg.c, paths, l.Err()
 			} else if svg.err != nil {
-				return svg.c, svg.err
+				return svg.c, paths, svg.err
 			} else if svg.c == nil {
-				return svg.c, fmt.Errorf("expected SVG tag")
+				return svg.c, paths, fmt.Errorf("expected SVG tag")
 			}
 			if svg.c.W == 0.0 || svg.c.H == 0.0 {
 				svg.c.Fit(0.0)
 			}
-			return svg.c, nil
+			return svg.c, paths, nil
 		case xml.StartTagToken:
 			tag := string(data[1:])
 			tt, attrNames, attrs := svg.parseAttributes(l)
@@ -911,7 +935,7 @@ func ParseSVG(r io.Reader) (*Canvas, error) {
 				width, height, viewbox := svg.parseViewBox(attrs["width"], attrs["height"], attrs["viewBox"])
 				svg.init(width, height, viewbox)
 			} else if tag != "svg" && svg.c == nil {
-				return svg.c, fmt.Errorf("expected SVG tag")
+				return svg.c, paths, fmt.Errorf("expected SVG tag")
 			}
 
 			// handle special tags
@@ -921,7 +945,7 @@ func ParseSVG(r io.Reader) (*Canvas, error) {
 					svg.parseStyle(data)
 					tt, data = l.Next() // end token
 				} else {
-					return svg.c, fmt.Errorf("bad style tag")
+					return svg.c, paths, fmt.Errorf("bad style tag")
 				}
 				break
 			} else if tag == "defs" {
@@ -941,8 +965,17 @@ func ParseSVG(r io.Reader) (*Canvas, error) {
 			}
 			svg.setStyling(props)
 
-			// draw shapes such as circles, paths, etc.
-			svg.drawShape(tag, attrs)
+			pathX, pathY, path := svg.toPath(tag, attrs)
+			if path != nil {
+				// draw shapes such as circles, paths, etc.
+				svg.ctx.DrawPath(pathX, pathY, path)
+				paths = append(paths, SVGPath{
+					Tag: tag,
+					X: pathX,
+					Y: pathY,
+					Path: path,
+				})
+			}
 
 			// set linearGradient, markers, etc.
 			// these defs depend on the shape or size of the path

--- a/svg.go
+++ b/svg.go
@@ -831,7 +831,6 @@ func (svg *svgParser) toPath(tag string, attrs map[string]string) (x float64, y 
 		if err != nil && svg.err == nil {
 			svg.err = parse.NewErrorLexer(svg.z, "bad path: %w", err)
 		}
-		x, y = 0, 0
 	case "polygon", "polyline":
 		path = &Path{}
 		points := svg.parsePoints(attrs["points"])
@@ -845,7 +844,6 @@ func (svg *svgParser) toPath(tag string, attrs map[string]string) (x float64, y 
 		if tag == "polygon" {
 			path.Close()
 		}
-		x, y = 0, 0
 	case "line":
 		x1 := svg.parseDimension(attrs["x1"], svg.width)
 		y1 := svg.parseDimension(attrs["y1"], svg.height)
@@ -886,6 +884,7 @@ func (svg *svgParser) drawShape(tag string, attrs map[string]string) {
 
 type SVGPath struct {
 	Tag string
+	X, Y float64
 	*Path
 }
 
@@ -970,6 +969,8 @@ func parseSVGFull(r io.Reader) (*Canvas, []SVGPath, error) {
 				svg.ctx.DrawPath(pathX, pathY, path)
 				paths = append(paths, SVGPath{
 					Tag: tag,
+					X: pathX,
+					Y: pathY,
 					Path: path,
 				})
 			}

--- a/svg.go
+++ b/svg.go
@@ -847,19 +847,19 @@ func (svg *svgParser) toPath(tag string, attrs map[string]string) (x float64, y 
 		}
 		x, y = 0, 0
 	case "line":
-		path = &Path{}
 		x1 := svg.parseDimension(attrs["x1"], svg.width)
 		y1 := svg.parseDimension(attrs["y1"], svg.height)
 		x2 := svg.parseDimension(attrs["x2"], svg.width)
 		y2 := svg.parseDimension(attrs["y2"], svg.height)
+		path = &Path{}
 		path.MoveTo(x1, y1)
 		path.LineTo(x2, y2)
 	case "rect":
-		path = &Path{}
 		x = svg.parseDimension(attrs["x"], svg.width)
 		y = svg.parseDimension(attrs["y"], svg.height)
 		width := svg.parseDimension(attrs["width"], svg.width)
 		height := svg.parseDimension(attrs["height"], svg.height)
+		path = &Path{}
 		if attrs["rx"] == "" && attrs["ry"] == "" {
 			path = Rectangle(width, height)
 		} else {
@@ -886,7 +886,6 @@ func (svg *svgParser) drawShape(tag string, attrs map[string]string) {
 
 type SVGPath struct {
 	Tag string
-	X, Y float64
 	*Path
 }
 
@@ -971,8 +970,6 @@ func parseSVGFull(r io.Reader) (*Canvas, []SVGPath, error) {
 				svg.ctx.DrawPath(pathX, pathY, path)
 				paths = append(paths, SVGPath{
 					Tag: tag,
-					X: pathX,
-					Y: pathY,
 					Path: path,
 				})
 			}

--- a/svg.go
+++ b/svg.go
@@ -884,6 +884,7 @@ func (svg *svgParser) drawShape(tag string, attrs map[string]string) {
 
 type SVGPath struct {
 	Tag string
+	Attrs map[string]string
 	X, Y float64
 	*Path
 }
@@ -967,8 +968,21 @@ func parseSVGFull(r io.Reader) (*Canvas, []SVGPath, error) {
 			if path != nil {
 				// draw shapes such as circles, paths, etc.
 				svg.ctx.DrawPath(pathX, pathY, path)
+
+				// Copy tag attributes map, excluding `d` which is where
+				// path data is stored. Since the path is already returned as
+				// `*Path`, there's not much point to returning `d`, and for
+				// large/many paths it can be wasteful of memory to return it.
+				attrsNoD := map[string]string{}
+				for key, value := range attrs {
+					if key != "d" {
+						attrsNoD[key] = value
+					}
+				}
+
 				paths = append(paths, SVGPath{
 					Tag: tag,
+					Attrs: attrsNoD,
 					X: pathX,
 					Y: pathY,
 					Path: path,

--- a/tests/latex/main.go
+++ b/tests/latex/main.go
@@ -2,7 +2,7 @@
 
 package fuzz
 
-import "github.com/tdewolff/canvas"
+import "github.com/Seanld/canvas"
 
 // Fuzz is a fuzz test.
 func Fuzz(data []byte) int {

--- a/tests/svg/main.go
+++ b/tests/svg/main.go
@@ -2,7 +2,7 @@
 
 package fuzz
 
-import "github.com/tdewolff/canvas"
+import "github.com/Seanld/canvas"
 
 // Fuzz is a fuzz test.
 func Fuzz(data []byte) int {

--- a/text.go
+++ b/text.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/tdewolff/canvas/text"
+	"github.com/Seanld/canvas/text"
 	"github.com/tdewolff/font"
 )
 


### PR DESCRIPTION
I'm adding the ability to draw arced/circular text to my system which depends on this library, and it requires drawing the characters one by one, to determine rotations for each separately from the rest of the line. Trying to do this without access to the glyphs directly is convoluted, and simply making it public solves my use case.