### PR TITLE
Make FontFace's glyphs public

### DIFF
--- a/font.go
+++ b/font.go
@@ -693,11 +693,14 @@ func (face *FontFace) LineHeight() float64 {
 	return metrics.Ascent + metrics.Descent
 }
 
+func (face *FontFace) Glyphs(s string) []text.Glyph {
+	ppem := face.PPEM(DefaultResolution)
+	return face.Font.shaper.Shape(s, ppem, face.Direction, face.Script, face.Language, face.Font.features, face.Font.variations)
+}
+
 // TextWidth returns the width of a given string in millimeters.
 func (face *FontFace) TextWidth(s string) float64 {
-	ppem := face.PPEM(DefaultResolution)
-	glyphs := face.Font.shaper.Shape(s, ppem, face.Direction, face.Script, face.Language, face.Font.features, face.Font.variations)
-	return face.textWidth(glyphs)
+	return face.textWidth(face.Glyphs(s))
 }
 
 func (face *FontFace) textWidth(glyphs []text.Glyph) float64 {
@@ -740,8 +743,7 @@ func (face *FontFace) Decorate(width float64) *Path {
 // ToPath converts a string to its glyph paths.
 func (face *FontFace) ToPath(s string) (*Path, float64, error) {
 	ppem := face.PPEM(DefaultResolution)
-	glyphs := face.Font.shaper.Shape(s, ppem, face.Direction, face.Script, face.Language, face.Font.features, face.Font.variations)
-	return face.toPath(glyphs, ppem)
+	return face.toPath(face.Glyphs(s), ppem)
 }
 
 func (face *FontFace) toPath(glyphs []text.Glyph, ppem uint16) (*Path, float64, error) {


### PR DESCRIPTION
Had to make a new PR because I accidentally mixed it with changes from my other active PR. This is standalone.

I'm adding the ability to draw arced/circular text to my system which depends on this library, and it requires drawing the characters one by one, to determine rotations for each separately from the rest of the line. Trying to do this without access to the glyphs directly is convoluted, and simply making it public solves my use case.