### PR TITLE
Allow inserting custom CSS in the SVG renderer

### DIFF
--- a/renderers/svg/svg.go
+++ b/renderers/svg/svg.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
+	"html"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -43,6 +44,7 @@ type SVG struct {
 	maskID        int
 	patterns      map[canvas.Gradient]string
 	classes       []string
+	customStyle   string
 	opts          *Options
 }
 
@@ -76,6 +78,9 @@ func New(w io.Writer, width, height float64, opts *Options) *SVG {
 func (r *SVG) Close() error {
 	if r.opts.EmbedFonts {
 		r.writeFonts()
+	}
+	if r.customStyle != "" {
+		fmt.Fprintf(r.w, "<style>%s</style>", html.EscapeString(r.customStyle))
 	}
 	_, err := fmt.Fprintf(r.w, "</svg>")
 	if r.opts.Compression != 0 {
@@ -153,6 +158,11 @@ func (r *SVG) RemoveClass(class string) {
 // SetImageEncoding sets the image encoding to Loss or Lossless.
 func (r *SVG) SetImageEncoding(enc canvas.ImageEncoding) {
 	r.opts.ImageEncoding = enc
+}
+
+// SetCustomStyle defines a custom CSS code to add in the SVG
+func (r *SVG) SetCustomStyle(style string) {
+	r.customStyle = style
 }
 
 // Size returns the size of the canvas in millimeters.


### PR DESCRIPTION
This adds a method in the SVG renderer to insert custom styles.

My main use case for this is to specify custom font URLs while `EmbedFonts` is set to `false` (make the font work without the overhead of base64 encoding/transfer).

Although we [discussed](https://github.com/tdewolff/canvas/discussions/340) initially about a more specific design, it ended-up being more complicated than I expected, and so I decided to fall-back on a simpler approach.

This is because the proper way to define a custom CSS font is not as trivial as a single font URL, and this way I can directly import Google fonts (like `<style>@import url("https://fonts.googleapis.com/css?family=Roboto:500i");</style>`) without making the API unnecessarily complicated.
