### PR TITLE
feat: `parseSVG` implement `radialGradient`

### DIFF
--- a/svg.go
+++ b/svg.go
@@ -516,7 +516,7 @@ func (svg *svgParser) parseDefs(l *xml.Lexer) {
 				tag.attrs["r"] = "50%"
 			}
 			if _, ok := tag.attrs["fx"]; !ok {
-				tag.attrs["fx"] = tag.attrs["cy"]
+				tag.attrs["fx"] = tag.attrs["cx"]
 			}
 			if _, ok := tag.attrs["fy"]; !ok {
 				tag.attrs["fy"] = tag.attrs["cy"]


### PR DESCRIPTION
# About
This adds the radial gradient feature, which was deferred previously #235.
It works correctly, at least for the use cases I need.