### PR TITLE
Fix radial gradient color handling and root validation

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -96,7 +96,7 @@ func NewGradient() Grad {
 
 // Add adds a new color stop to a gradient.
 func (g *Grad) Add(t float64, color color.RGBA) {
-	stop := Stop{math.Min(math.Max(t, 0.0), 1.0), color}
+	stop := Stop{math.Min(math.Max(t, 0.0), 1.0), rgbaColor(color)}
 	// insert or replace stop and keep sort order
 	for i := range *g {
 		if Equal((*g)[i].Offset, stop.Offset) {

--- a/colors.go
+++ b/colors.go
@@ -250,12 +250,27 @@ func (g *RadialGradient) At(x, y float64) color.RGBA {
 	b := pd.Dot(g.cd) + g.R0*g.dr
 	c := pd.Dot(pd) - g.R0*g.R0
 	t0, t1 := solveQuadraticFormula(g.a, -2.0*b, c)
-	if !math.IsNaN(t1) {
+
+	valid := func(t float64) bool {
+		return !math.IsNaN(t) && t >= 0 && t <= 1 && g.R0+g.dr*t >= 0
+	}
+	hasPositive := func(t float64) bool {
+		return !math.IsNaN(t) && t > 0 && g.R0+g.dr*t >= 0
+	}
+
+	// Pick the largest valid t (t1 >= t0 from solveQuadraticFormula).
+	if valid(t1) {
 		return g.Grad.At(t1)
-	} else if !math.IsNaN(t0) {
+	}
+	if valid(t0) {
 		return g.Grad.At(t0)
 	}
-	return Transparent
+
+	// No valid t in [0,1]. Extend boundary colors.
+	if hasPositive(t0) || hasPositive(t1) {
+		return g.Grad.At(1)
+	}
+	return g.Grad.At(0)
 }
 
 // ColorSpace defines the color space within the RGB color model. All colors passed to this library are assumed to be in the sRGB color space, which is a ubiquitous assumption in most software. This works great for most applications, but fails when blending semi-transparent layers. See an elaborate explanation at https://blog.johnnovak.net/2016/09/21/what-every-coder-should-know-about-gamma/, which goes into depth of the problems of using sRGB for blending and the need for gamma correction. In short, we need to transform the colors, which are in the sRGB color space, to the linear color space, perform blending, and then transform them back to the sRGB color space.

--- a/colors_test.go
+++ b/colors_test.go
@@ -1,6 +1,7 @@
 package canvas
 
 import (
+	"fmt"
 	"image/color"
 	"testing"
 )
@@ -123,4 +124,163 @@ func TestGradAdd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRadialGradientAt(t *testing.T) {
+	red := color.RGBA{255, 0, 0, 255}
+	blue := color.RGBA{0, 0, 255, 255}
+
+	// Helper to build a radial gradient with red at t=0 and blue at t=1.
+	makeGrad := func(c0 Point, r0 float64, c1 Point, r1 float64) *RadialGradient {
+		g := NewRadialGradient(c0, r0, c1, r1)
+		g.Add(0.0, red)
+		g.Add(1.0, blue)
+		return g
+	}
+
+	// colorApproxEqual allows small rounding differences from interpolation.
+	colorApproxEqual := func(a, b color.RGBA) bool {
+		diff := func(x, y uint8) int {
+			d := int(x) - int(y)
+			if d < 0 {
+				return -d
+			}
+			return d
+		}
+		return diff(a.R, b.R) <= 1 && diff(a.G, b.G) <= 1 && diff(a.B, b.B) <= 1 && diff(a.A, b.A) <= 1
+	}
+
+	tests := []struct {
+		name string
+		grad *RadialGradient
+		x, y float64
+		want color.RGBA
+	}{
+		{
+			name: "empty gradient returns transparent",
+			grad: NewRadialGradient(Point{0, 0}, 0, Point{0, 0}, 10),
+			x:    5,
+			y:    0,
+			want: Transparent,
+		},
+		{
+			name: "concentric at center returns first stop",
+			grad: makeGrad(Point{0, 0}, 0, Point{0, 0}, 10),
+			x:    0,
+			y:    0,
+			want: red,
+		},
+		{
+			name: "concentric at outer edge returns last stop",
+			grad: makeGrad(Point{0, 0}, 0, Point{0, 0}, 10),
+			x:    10,
+			y:    0,
+			want: blue,
+		},
+		{
+			name: "concentric beyond outer edge clamps to last stop",
+			grad: makeGrad(Point{0, 0}, 0, Point{0, 0}, 10),
+			x:    20,
+			y:    0,
+			want: blue,
+		},
+		{
+			name: "concentric at midpoint interpolates",
+			grad: makeGrad(Point{0, 0}, 0, Point{0, 0}, 10),
+			x:    5,
+			y:    0,
+			want: color.RGBA{128, 0, 127, 255},
+		},
+		{
+			name: "concentric along y axis",
+			grad: makeGrad(Point{0, 0}, 0, Point{0, 0}, 10),
+			x:    0,
+			y:    10,
+			want: blue,
+		},
+		{
+			name: "concentric with offset center",
+			grad: makeGrad(Point{5, 5}, 0, Point{5, 5}, 10),
+			x:    5,
+			y:    5,
+			want: red,
+		},
+		{
+			name: "concentric with offset center at edge",
+			grad: makeGrad(Point{5, 5}, 0, Point{5, 5}, 10),
+			x:    15,
+			y:    5,
+			want: blue,
+		},
+		{
+			name: "non-concentric gradient at inner center",
+			grad: makeGrad(Point{0, 0}, 0, Point{10, 0}, 10),
+			x:    0,
+			y:    0,
+			want: red,
+		},
+		{
+			name: "single stop gradient returns that stop everywhere",
+			grad: func() *RadialGradient {
+				g := NewRadialGradient(Point{0, 0}, 0, Point{0, 0}, 10)
+				g.Add(0.0, red)
+				return g
+			}(),
+			x:    5,
+			y:    0,
+			want: red,
+		},
+		{
+			name: "offset centers uses valid root not largest root",
+			grad: func() *RadialGradient {
+				g := NewRadialGradient(Point{30, 30}, 5, Point{170, 170}, 60)
+				g.Add(0.0, color.RGBA{255, 192, 203, 255})
+				g.Add(0.5, color.RGBA{255, 255, 255, 255})
+				g.Add(1.0, color.RGBA{0, 128, 0, 255})
+				return g
+			}(),
+			x:    160,
+			y:    111,
+			want: color.RGBA{180, 218, 180, 255},
+		},
+		{
+			name: "offset centers near outer boundary not clamped to last stop",
+			grad: func() *RadialGradient {
+				g := NewRadialGradient(Point{30, 30}, 5, Point{170, 170}, 60)
+				g.Add(0.0, color.RGBA{255, 192, 203, 255})
+				g.Add(0.5, color.RGBA{255, 255, 255, 255})
+				g.Add(1.0, color.RGBA{0, 128, 0, 255})
+				return g
+			}(),
+			x:    165,
+			y:    111,
+			want: color.RGBA{164, 210, 164, 255},
+		},
+		{
+			name: "concentric with semi-transparent stops",
+			grad: func() *RadialGradient {
+				g := NewRadialGradient(Point{0, 0}, 0, Point{0, 0}, 10)
+				g.Add(0.0, color.RGBA{128, 0, 0, 128})
+				g.Add(1.0, color.RGBA{0, 0, 128, 128})
+				return g
+			}(),
+			x:    0,
+			y:    0,
+			want: color.RGBA{128, 0, 0, 128},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.grad.At(tt.x, tt.y)
+			if !colorApproxEqual(got, tt.want) {
+				t.Errorf("At(%v, %v) = %v, want %v (within ±1 per channel)",
+					tt.x, tt.y, formatRGBA(got), formatRGBA(tt.want))
+			}
+		})
+	}
+}
+
+func formatRGBA(c color.RGBA) string {
+	return fmt.Sprintf("RGBA{%d, %d, %d, %d}", c.R, c.G, c.B, c.A)
 }

--- a/colors_test.go
+++ b/colors_test.go
@@ -1,0 +1,126 @@
+package canvas
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestGradAdd(t *testing.T) {
+	red := color.RGBA{255, 0, 0, 255}
+	green := color.RGBA{0, 255, 0, 255}
+	blue := color.RGBA{0, 0, 255, 255}
+	white := color.RGBA{255, 255, 255, 255}
+
+	tests := []struct {
+		name     string
+		initial  Grad
+		addT     float64
+		addColor color.RGBA
+		want     Grad
+	}{
+		{
+			name:     "add to empty gradient",
+			initial:  Grad{},
+			addT:     0.5,
+			addColor: red,
+			want:     Grad{{0.5, red}},
+		},
+		{
+			name:     "add at end",
+			initial:  Grad{{0.0, red}},
+			addT:     1.0,
+			addColor: blue,
+			want:     Grad{{0.0, red}, {1.0, blue}},
+		},
+		{
+			name:     "add at beginning",
+			initial:  Grad{{0.5, red}},
+			addT:     0.0,
+			addColor: blue,
+			want:     Grad{{0.0, blue}, {0.5, red}},
+		},
+		{
+			name:     "insert in middle maintains sort order",
+			initial:  Grad{{0.0, red}, {1.0, blue}},
+			addT:     0.5,
+			addColor: green,
+			want:     Grad{{0.0, red}, {0.5, green}, {1.0, blue}},
+		},
+		{
+			name:     "replace existing offset",
+			initial:  Grad{{0.0, red}, {0.5, green}, {1.0, blue}},
+			addT:     0.5,
+			addColor: white,
+			want:     Grad{{0.0, red}, {0.5, white}, {1.0, blue}},
+		},
+		{
+			name:     "clamp t below 0",
+			initial:  Grad{},
+			addT:     -0.5,
+			addColor: red,
+			want:     Grad{{0.0, red}},
+		},
+		{
+			name:     "clamp t above 1",
+			initial:  Grad{},
+			addT:     1.5,
+			addColor: red,
+			want:     Grad{{1.0, red}},
+		},
+		{
+			name:     "add multiple maintains order",
+			initial:  Grad{{0.2, red}, {0.8, blue}},
+			addT:     0.4,
+			addColor: green,
+			want:     Grad{{0.2, red}, {0.4, green}, {0.8, blue}},
+		},
+		{
+			name:     "add semi-transparent color clips to premultiplied",
+			initial:  Grad{},
+			addT:     0.5,
+			addColor: color.RGBA{255, 0, 0, 128},
+			want:     Grad{{0.5, color.RGBA{128, 0, 0, 128}}},
+		},
+		{
+			name:     "replace opaque with semi-transparent clips to premultiplied",
+			initial:  Grad{{0.0, red}, {0.5, green}, {1.0, blue}},
+			addT:     0.5,
+			addColor: color.RGBA{0, 255, 0, 64},
+			want:     Grad{{0.0, red}, {0.5, color.RGBA{0, 64, 0, 64}}, {1.0, blue}},
+		},
+		{
+			name:     "fully transparent color",
+			initial:  Grad{{0.0, red}},
+			addT:     1.0,
+			addColor: color.RGBA{0, 0, 0, 0},
+			want:     Grad{{0.0, red}, {1.0, color.RGBA{0, 0, 0, 0}}},
+		},
+		{
+			name:     "mixed transparent stops maintain order",
+			initial:  Grad{{0.0, color.RGBA{255, 0, 0, 200}}, {1.0, color.RGBA{0, 0, 255, 100}}},
+			addT:     0.5,
+			addColor: color.RGBA{0, 255, 0, 50},
+			want:     Grad{{0.0, color.RGBA{255, 0, 0, 200}}, {0.5, color.RGBA{0, 50, 0, 50}}, {1.0, color.RGBA{0, 0, 255, 100}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := make(Grad, len(tt.initial))
+			copy(g, tt.initial)
+			g.Add(tt.addT, tt.addColor)
+
+			if len(g) != len(tt.want) {
+				t.Fatalf("got %d stops, want %d", len(g), len(tt.want))
+			}
+			for i := range tt.want {
+				if !Equal(g[i].Offset, tt.want[i].Offset) {
+					t.Errorf("stop[%d].Offset = %v, want %v", i, g[i].Offset, tt.want[i].Offset)
+				}
+				if g[i].Color != tt.want[i].Color {
+					t.Errorf("stop[%d].Color = %v, want %v", i, g[i].Color, tt.want[i].Color)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Grad.Add was storing colors as-is, which could result in invalid (non-premultiplied) RGBA values in gradient stops. Pass colors through rgbaColor() to clip R/G/B channels to the alpha value. Add table-driven tests for Grad.Add covering insertion order, offset clamping, replacement, and premultiplied alpha normalization.

RadialGradient.At was using the first non-NaN root from the quadratic formula without checking that t is in [0,1] or that the radius at t is non-negative. This caused incorrect colors for non-concentric gradients with offset centers, where the larger root could be slightly out of range while the smaller root was valid. Now validates roots and extends boundary colors when no valid root exists, matching the pixman reference behavior.