### PR TITLE
SVG: write translucent paints as color plus opacity instead of rgba()

### DIFF
--- a/renderers/svg/svg.go
+++ b/renderers/svg/svg.go
@@ -174,8 +174,8 @@ func (r *SVG) Size() (float64, float64) {
 
 // RenderPath renders a path to the canvas using a style and a transformation matrix.
 func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix) {
-	fillPaint := r.writePaint(style.Fill, m)
-	strokePaint := r.writePaint(style.Stroke, m)
+	fillPaint, fillOpacity := r.writePaint(style.Fill, m)
+	strokePaint, strokeOpacity := r.writePaint(style.Stroke, m)
 
 	stroke := path
 	path = path.Copy().Transform(canvas.Identity.ReflectYAbout(r.height / 2.0).Mul(m))
@@ -205,6 +205,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 		if style.HasFill() {
 			if !style.Fill.IsColor() || style.Fill.Color != canvas.Black {
 				fmt.Fprintf(r.w, `" fill="%v`, fillPaint)
+				if fillOpacity != 1.0 {
+					fmt.Fprintf(r.w, `" fill-opacity="%v`, dec(fillOpacity))
+				}
 			}
 			if style.FillRule == canvas.EvenOdd {
 				fmt.Fprintf(r.w, `" fill-rule="evenodd`)
@@ -217,6 +220,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 		if style.HasFill() {
 			if !style.Fill.IsColor() || style.Fill.Color != canvas.Black {
 				fmt.Fprintf(b, ";fill:%v", fillPaint)
+				if fillOpacity != 1.0 {
+					fmt.Fprintf(b, ";fill-opacity:%v", dec(fillOpacity))
+				}
 			}
 			if style.FillRule == canvas.EvenOdd {
 				fmt.Fprintf(b, ";fill-rule:evenodd")
@@ -226,6 +232,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 		}
 		if style.HasStroke() && !strokeUnsupported {
 			fmt.Fprintf(b, `;stroke:%v`, strokePaint)
+			if strokeOpacity != 1.0 {
+				fmt.Fprintf(b, ";stroke-opacity:%v", dec(strokeOpacity))
+			}
 			if style.StrokeWidth != 1.0 {
 				fmt.Fprintf(b, ";stroke-width:%v", dec(style.StrokeWidth))
 			}
@@ -281,6 +290,9 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 		fmt.Fprintf(r.w, `<path d="%s`, stroke.ToSVG())
 		if !style.Stroke.IsColor() || style.Stroke.Color != canvas.Black {
 			fmt.Fprintf(r.w, `" fill="%v`, strokePaint)
+			if strokeOpacity != 1.0 {
+				fmt.Fprintf(r.w, `" fill-opacity="%v`, dec(strokeOpacity))
+			}
 		}
 		if style.FillRule == canvas.EvenOdd {
 			fmt.Fprintf(r.w, `" fill-rule="evenodd`)
@@ -290,7 +302,7 @@ func (r *SVG) RenderPath(path *canvas.Path, style canvas.Style, m canvas.Matrix)
 	}
 }
 
-func (r *SVG) writeFontStyle(face, faceMain *canvas.FontFace, rtl bool, fill string) {
+func (r *SVG) writeFontStyle(face, faceMain *canvas.FontFace, rtl bool, fill string, fillOpacity float64) {
 	differences := 0
 	boldness := face.Style.CSS()
 	if face.Style&canvas.FontItalic != faceMain.Style&canvas.FontItalic {
@@ -332,12 +344,18 @@ func (r *SVG) writeFontStyle(face, faceMain *canvas.FontFace, rtl bool, fill str
 
 		if !face.Fill.Equal(faceMain.Fill) {
 			fmt.Fprintf(r.w, `;fill:%v`, fill)
+			if fillOpacity != 1.0 {
+				fmt.Fprintf(r.w, `;fill-opacity:%v`, dec(fillOpacity))
+			}
 		}
 		if rtl {
 			fmt.Fprintf(r.w, `;direction:rtl`)
 		}
 	} else if differences == 1 && !face.Fill.Equal(faceMain.Fill) {
 		fmt.Fprintf(r.w, `" fill="%v`, fill)
+		if fillOpacity != 1.0 {
+			fmt.Fprintf(r.w, `" fill-opacity="%v`, dec(fillOpacity))
+		}
 	} else if 0 < differences {
 		fmt.Fprintf(r.w, `" style="`)
 		buf := &bytes.Buffer{}
@@ -354,6 +372,9 @@ func (r *SVG) writeFontStyle(face, faceMain *canvas.FontFace, rtl bool, fill str
 		}
 		if !face.Fill.Equal(faceMain.Fill) {
 			fmt.Fprintf(buf, `;fill:%v`, fill)
+			if fillOpacity != 1.0 {
+				fmt.Fprintf(buf, `;fill-opacity:%v`, dec(fillOpacity))
+			}
 		}
 		if rtl {
 			fmt.Fprintf(r.w, `;direction:rtl`)
@@ -400,7 +421,11 @@ func (r *SVG) RenderText(text *canvas.Text, m canvas.Matrix) {
 	}
 	fmt.Fprintf(r.w, ` %vpx %s`, num(faceMain.Size), faceMain.Name())
 	if !faceMain.Fill.IsColor() || faceMain.Fill.Color != canvas.Black {
-		fmt.Fprintf(r.w, `;fill:%v`, r.writePaint(faceMain.Fill, m))
+		fill, fillOpacity := r.writePaint(faceMain.Fill, m)
+		fmt.Fprintf(r.w, `;fill:%v`, fill)
+		if fillOpacity != 1.0 {
+			fmt.Fprintf(r.w, `;fill-opacity:%v`, dec(fillOpacity))
+		}
 	}
 	if text.WritingMode != canvas.HorizontalTB {
 		if text.WritingMode == canvas.VerticalLR {
@@ -433,8 +458,9 @@ func (r *SVG) RenderText(text *canvas.Text, m canvas.Matrix) {
 			if span.Direction == ctext.RightToLeft {
 				x += span.Width
 			}
+			fill, fillOpacity := r.writePaint(span.Face.Fill, m)
 			fmt.Fprintf(r.w, `<tspan x="%v" y="%v`, num(x), num(y))
-			r.writeFontStyle(span.Face, faceMain, span.Direction == ctext.RightToLeft, r.writePaint(span.Face.Fill, m))
+			r.writeFontStyle(span.Face, faceMain, span.Direction == ctext.RightToLeft, fill, fillOpacity)
 			r.writeClasses(r.w)
 			fmt.Fprintf(r.w, `">`)
 			xml.EscapeText(r.w, []byte(span.Text))
@@ -554,15 +580,18 @@ func splitImageAlphaChannel(img image.Image) (image.Image, image.Image) {
 	return opaque, mask
 }
 
-func (r *SVG) writePaint(paint canvas.Paint, m canvas.Matrix) string {
+// writePaint returns the value for a fill or stroke property, and the opacity to write to the
+// accompanying fill-opacity or stroke-opacity property. The alpha is never baked into the returned
+// color, see splitAlpha.
+func (r *SVG) writePaint(paint canvas.Paint, m canvas.Matrix) (string, float64) {
 	if paint.IsPattern() {
 		// TODO
-		return ""
+		return "", 1.0
 	} else if paint.IsGradient() {
 		var def string
 		ref := fmt.Sprintf("d%v", len(r.defs))
 		if v, ok := r.defs[[2]any{paint.Gradient, m}]; ok {
-			return fmt.Sprintf("url(#%v)", v[0])
+			return fmt.Sprintf("url(#%v)", v[0]), 1.0
 		} else if linearGradient, ok := paint.Gradient.(*canvas.LinearGradient); ok {
 			sb := strings.Builder{}
 			if m.IsSimilarity() {
@@ -575,7 +604,7 @@ func (r *SVG) writePaint(paint canvas.Paint, m canvas.Matrix) string {
 				fmt.Fprintf(&sb, `<linearGradient id="%v" gradientUnits="userSpaceOnUse" gradientTransform="%v" x1="%v" y1="%v" x2="%v" y2="%v">`, ref, m.ToSVG(r.height), dec(linearGradient.Start.X), -dec(linearGradient.Start.Y), dec(linearGradient.End.X), -dec(linearGradient.End.Y))
 			}
 			for _, stop := range linearGradient.Grad {
-				fmt.Fprintf(&sb, `<stop offset="%v" stop-color="%v"/>`, dec(stop.Offset), canvas.CSSColor(stop.Color))
+				writeStop(&sb, stop)
 			}
 			fmt.Fprintf(&sb, `</linearGradient>`)
 			def = sb.String()
@@ -594,14 +623,25 @@ func (r *SVG) writePaint(paint canvas.Paint, m canvas.Matrix) string {
 				fmt.Fprintf(&sb, `<radialGradient id="%v" gradientUnits="userSpaceOnUse" gradientTransform="%v" fx="%v" fy="%v" fr="%v" cx="%v" cy="%v" r="%v">`, ref, m.ToSVG(r.height), dec(radialGradient.C0.X), -dec(radialGradient.C0.Y), dec(radialGradient.R0), dec(radialGradient.C1.X), -dec(radialGradient.C1.Y), dec(radialGradient.R1))
 			}
 			for _, stop := range radialGradient.Grad {
-				fmt.Fprintf(&sb, `<stop offset="%v" stop-color="%v"/>`, dec(stop.Offset), canvas.CSSColor(stop.Color))
+				writeStop(&sb, stop)
 			}
 			fmt.Fprintf(&sb, `</radialGradient>`)
 			def = sb.String()
 		}
 		r.defs[[2]any{paint.Gradient, m}] = [2]string{ref, def}
-		return fmt.Sprintf("url(#%v)", ref)
+		return fmt.Sprintf("url(#%v)", ref), 1.0
 	} else {
-		return fmt.Sprintf("%v", canvas.CSSColor(paint.Color))
+		col, opacity := splitAlpha(paint.Color)
+		return col.String(), opacity
 	}
+}
+
+// writeStop writes a gradient stop, keeping the alpha out of stop-color and in stop-opacity.
+func writeStop(sb *strings.Builder, stop canvas.Stop) {
+	col, opacity := splitAlpha(stop.Color)
+	fmt.Fprintf(sb, `<stop offset="%v" stop-color="%v"`, dec(stop.Offset), col)
+	if opacity != 1.0 {
+		fmt.Fprintf(sb, ` stop-opacity="%v"`, dec(opacity))
+	}
+	fmt.Fprintf(sb, `/>`)
 }

--- a/renderers/svg/svg_test.go
+++ b/renderers/svg/svg_test.go
@@ -1,7 +1,13 @@
 package svg
 
 import (
+	"bytes"
+	"image/color"
+	"strings"
 	"testing"
+
+	"github.com/tdewolff/canvas"
+	"github.com/tdewolff/test"
 )
 
 func TestSVGText(t *testing.T) {
@@ -29,4 +35,99 @@ func TestSVGText(t *testing.T) {
 	//textLayer{text, Identity}.WriteSVG(svg)
 	//s := regexp.MustCompile(`base64,.+'`).ReplaceAllString(buf.String(), "base64,'") // remove embedded font
 	//test.String(t, s, `<style>`+"\n"+`@font-face{font-family:'dejavu-serif';src:url('data:font/truetype;base64,');}`+"\n"+`@font-face{font-family:'eb-garamond';src:url('data:font/opentype;base64,');}`+"\n"+`</style><text x="0" y="0" style="font: 12px dejavu-serif"><tspan x="0" y="7.421875" style="font:8px dejavu-serif">dejaVu8</tspan><tspan x="0" y="20.453125" letter-spacing="1" style="font-style:italic;fill:#f00">glyphspacing</tspan><tspan x="0" y="33.725625" style="font:700 6.996px dejavu-serif">dejaVu12sub</tspan><tspan x="0" y="38.5" style="font:700 10px eb-garamond">garamond10</tspan></text><path d="M0 22.703125H91.71875V21.803125H0z" fill="#f00"/>`)
+}
+
+// renderSVG draws onto a 100x100 canvas and returns the SVG output without the <svg> header.
+func renderSVG(draw func(*canvas.Context)) string {
+	c := canvas.New(100.0, 100.0)
+	draw(canvas.NewContext(c))
+
+	buf := &bytes.Buffer{}
+	r := New(buf, 100.0, 100.0, nil)
+	c.RenderTo(r)
+	r.Close()
+
+	s := buf.String()
+	if i := strings.IndexByte(s, '>'); i != -1 {
+		s = s[i+1:]
+	}
+	return strings.TrimSuffix(s, `</svg>`)
+}
+
+// SVG 1.1 does not allow rgba() where a <color> is expected, renderers that implement SVG 1.1
+// rather than CSS Color 4 discard the value and fall back to black. Translucent paints must be
+// written as an opaque color with the alpha in a separate *-opacity property. See issue #385.
+func TestPaintOpacity(t *testing.T) {
+	blue := color.NRGBA{R: 0x3B, G: 0x82, B: 0xF6, A: 178}
+
+	var tests = []struct {
+		name string
+		draw func(*canvas.Context)
+		svg  string
+	}{
+		{"opaque fill", func(ctx *canvas.Context) {
+			ctx.SetFillColor(canvas.Red)
+			ctx.DrawPath(10.0, 10.0, canvas.Rectangle(80.0, 80.0))
+		}, `<path d="M10 90H90V10H10z" fill="#f00"/>`},
+
+		{"translucent fill", func(ctx *canvas.Context) {
+			ctx.SetFillColor(blue)
+			ctx.DrawPath(10.0, 10.0, canvas.Rectangle(80.0, 80.0))
+		}, `<path d="M10 90H90V10H10z" fill="#3a82f7" fill-opacity=".69803922"/>`},
+
+		{"translucent black fill", func(ctx *canvas.Context) {
+			ctx.SetFillColor(canvas.RGBA(0.0, 0.0, 0.0, 0.5))
+			ctx.DrawPath(10.0, 10.0, canvas.Rectangle(80.0, 80.0))
+		}, `<path d="M10 90H90V10H10z" fill="#000" fill-opacity=".49803922"/>`},
+
+		{"translucent fill with stroke", func(ctx *canvas.Context) {
+			ctx.SetFillColor(blue)
+			ctx.SetStrokeColor(canvas.Black)
+			ctx.SetStrokeWidth(1.0)
+			ctx.DrawPath(10.0, 10.0, canvas.Rectangle(80.0, 80.0))
+		}, `<path d="M10 90H90V10H10z" style="fill:#3a82f7;fill-opacity:.69803922;stroke:#000"/>`},
+
+		{"translucent stroke", func(ctx *canvas.Context) {
+			ctx.SetFillColor(canvas.Transparent)
+			ctx.SetStrokeColor(canvas.RGBA(1.0, 0.0, 0.0, 0.5))
+			ctx.SetStrokeWidth(1.0)
+			ctx.DrawPath(10.0, 10.0, canvas.Rectangle(80.0, 80.0))
+		}, `<path d="M10 90H90V10H10z" style="fill:none;stroke:#f00;stroke-opacity:.49803922"/>`},
+
+		{"translucent gradient stop", func(ctx *canvas.Context) {
+			grad := canvas.NewLinearGradient(canvas.Point{X: 0.0, Y: 0.0}, canvas.Point{X: 100.0, Y: 0.0})
+			grad.Add(0.0, canvas.RGBA(0.0, 1.0, 0.0, 0.25))
+			grad.Add(1.0, canvas.Blue)
+			ctx.SetFill(canvas.Paint{Gradient: grad})
+			ctx.DrawPath(10.0, 10.0, canvas.Rectangle(80.0, 80.0))
+		}, `<path d="M10 90H90V10H10z" fill="url(#d0)"/><defs><linearGradient id="d0" gradientUnits="userSpaceOnUse" x1="10" y1="90" x2="110" y2="90"><stop offset="0" stop-color="#0f0" stop-opacity=".24705882"/><stop offset="1" stop-color="#00f"/></linearGradient></defs>`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := renderSVG(tt.draw)
+			test.String(t, s, tt.svg)
+			if strings.Contains(s, "rgba(") {
+				test.Fail(t, "output must not contain rgba(), it is not valid SVG 1.1:", s)
+			}
+		})
+	}
+}
+
+func TestSplitAlpha(t *testing.T) {
+	var tests = []struct {
+		col     color.RGBA
+		css     string
+		opacity float64
+	}{
+		{canvas.Red, "#f00", 1.0},
+		{canvas.Black, "#000", 1.0},
+		{canvas.Transparent, "#000", 0.0},
+		{canvas.RGBA(1.0, 0.0, 0.0, 0.5), "#f00", 0.49803921568627452},
+		{color.RGBA{R: 41, G: 91, B: 172, A: 178}, "#3a82f7", 0.69803921568627447},
+	}
+	for _, tt := range tests {
+		col, opacity := splitAlpha(tt.col)
+		test.String(t, col.String(), tt.css)
+		test.Float(t, opacity, tt.opacity)
+	}
 }

--- a/renderers/svg/util.go
+++ b/renderers/svg/util.go
@@ -2,6 +2,7 @@ package svg
 
 import (
 	"fmt"
+	"image/color"
 	"math"
 	"strings"
 
@@ -10,6 +11,18 @@ import (
 )
 
 ////////////////////////////////////////////////////////////////
+
+// splitAlpha splits an alpha premultiplied color into an opaque color and an opacity in [0,1].
+// SVG 1.1 has no rgba() color notation, translucent paints must be written as an opaque color
+// with the alpha in a separate fill-opacity/stroke-opacity/stop-opacity property. Renderers that
+// implement SVG 1.1 instead of CSS Color 4 discard an rgba() value and fall back to black.
+func splitAlpha(col color.RGBA) (canvas.CSSColor, float64) {
+	if col.A == 255 {
+		return canvas.CSSColor(col), 1.0
+	}
+	nrgba := color.NRGBAModel.Convert(col).(color.NRGBA)
+	return canvas.CSSColor{R: nrgba.R, G: nrgba.G, B: nrgba.B, A: 255}, float64(col.A) / 255.0
+}
 
 type num float64
 


### PR DESCRIPTION
Fixes #385.

The SVG renderer wrote translucent paints as `fill:rgba(58,130,246,.69803922)`. SVG 1.1 does not allow a function where a [`<color>`](https://www.w3.org/TR/SVG11/types.html#DataTypeColor) is expected, so renderers implementing SVG 1.1 rather than CSS Color 4 discard the declaration and fall back to the initial `fill` — black. Browsers accept it, so it only shows up outside a browser (Inkscape, librsvg, most print/CAD toolchains).

### Fix

`splitAlpha` un-premultiplies a color into an opaque `#rrggbb` plus an opacity in `[0,1]`. `writePaint` returns both, and each call site writes the opacity to the matching property — `fill-opacity`, `stroke-opacity`, or `stop-opacity` — only when it is not `1.0`. Output for the issue's reproducer:

```diff
-<path d="M10 90H90V10H10z" style="fill:rgba(58,130,246,.69803922);stroke:#000"/>
+<path d="M10 90H90V10H10z" style="fill:#3a82f7;fill-opacity:.69803922;stroke:#000"/>
```

Covered: path fill and stroke in both attribute and `style` form, the explicitly-drawn stroke path (`strokeUnsupported`), text fill in `RenderText` and all three branches of `writeFontStyle`, and linear/radial gradient stops (`stop-color` had the same problem).

### Not writing the alpha twice

#263 fixed this in Dec 2023 and 7d6baa9 removed it in Jul 2024 as a drive-by while working on #307. I could not find a recorded failure case, but the obvious hazard is emitting the alpha in both `rgba()` and `fill-opacity`, which darkens the result. That cannot happen here: `splitAlpha` returns a color with `A = 255`, so the alpha exists in exactly one place. `TestSplitAlpha` pins that, and every case in `TestPaintOpacity` additionally asserts `rgba(` never appears in the output, so this cannot regress a third time.

The SVG parser in `svg.go` already handles `fill-opacity`, `stroke-opacity` and `stop-opacity`, so round-tripping is unaffected.

### Verification

`inkscape out.svg -o out.png` on the reproducer from the issue now samples `srgba(57,130,248,0.698039)` inside the square, instead of solid black. `go test ./renderers/svg/ ./renderers/pdf/ .` passes.

One leftover: `examples/go-chart/output.svg` is a committed render that still contains one `rgba(...)` from before this change. I left it alone rather than regenerate the example's four output files in this PR — happy to add that if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
